### PR TITLE
Add `definedTargets` to the sbt build target

### DIFF
--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -1247,7 +1247,7 @@ trait SbtBuildTarget {
   /** The build targets defined by the sbt build represented
     * in this target. It can contain normal project targets or sbt
     * build targets if this target represents an sbt meta-meta build. */
-  def definedTargets: List[BuildTargetIdentifier]
+  def children: List[BuildTargetIdentifier]
 }
 ```
 
@@ -1258,7 +1258,7 @@ The sbt build target for `M1` will have `A` and `B` as the defined targets and `
 Similarly, the sbt build target for `M2` will have `M1` as the defined target and no parent.
 
 Clients can use this information to reconstruct the tree of sbt meta builds. The
-`parent` information can be defined from `definedTargets` but it's provided by the server to
+`parent` information can be defined from `children` but it's provided by the server to
 simplify the data processing on the client side.
 
 ## Appendix

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -184,7 +184,7 @@ trait BuildTargetCapabilities {
 
 ### Build Target Identifier
 
-A unique identifier for a target.
+A unique identifier for a target, usually the project base directory.
 
 ```scala
 trait BuildTargetIdentifer {
@@ -1228,9 +1228,6 @@ support for sbt build files. This metadata is embedded in the `data: Option[Json
 
 ```scala
 trait SbtBuildTarget {
-  /** An optional parent if the target has an sbt meta project. */
-  def parent: Option[BuildTargetIdentifier]
-  
   /** The sbt version. Useful to support version-dependent syntax. */
   def sbtVersion: String
   
@@ -1240,13 +1237,23 @@ trait SbtBuildTarget {
   /** The classpath for the sbt build (including sbt jars). */
   def classpath: List[Uri]
   
-  /** The Scala build target associated with this sbt build.
-    * It contains the scala version and the scala jars used. */
+  /** The Scala build target describing the scala
+   * version and scala jars used by this sbt version. */
   def scalaBuildTarget: ScalaBuildTarget
+  
+  /** An optional parent if the target has an sbt meta project. */
+  def parent: Option[BuildTargetIdentifier]
+  
+  /** The build targets defined by the sbt build represented
+    * in this target. It can contain scala targets or sbt build
+    * targets if this target represents an sbt meta-meta build. */
+  def definedTargets: List[Json]
 }
 ```
 
-where `parent` points to the sbt metabuild of this target (if any).
+Clients can use this information to reconstruct the tree of sbt meta builds in a simple way. The
+`parent` information can be defined from `definedTargets` but it's provided by the server to
+simplify the data processing on the client side.
 
 ## Appendix
 

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -1244,9 +1244,9 @@ trait SbtBuildTarget {
   /** An optional parent if the target has an sbt meta project. */
   def parent: Option[BuildTargetIdentifier]
   
-  /** The build targets defined by the sbt build represented
-    * in this target. It can contain normal project targets or sbt
-    * build targets if this target represents an sbt meta-meta build. */
+  /** The inverse of parent, list of targets that have this build target
+    * defined as their parent. It can contain normal project targets or
+    * sbt build targets if this target represents an sbt meta-meta build. */
   def children: List[BuildTargetIdentifier]
 }
 ```

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -1245,13 +1245,19 @@ trait SbtBuildTarget {
   def parent: Option[BuildTargetIdentifier]
   
   /** The build targets defined by the sbt build represented
-    * in this target. It can contain scala targets or sbt build
-    * targets if this target represents an sbt meta-meta build. */
-  def definedTargets: List[Json]
+    * in this target. It can contain normal project targets or sbt
+    * build targets if this target represents an sbt meta-meta build. */
+  def definedTargets: List[BuildTargetIdentifier]
 }
 ```
 
-Clients can use this information to reconstruct the tree of sbt meta builds in a simple way. The
+For example, say we have a project in `/foo/bar` defining projects `A` and `B` and two meta builds
+`M1` (defined in `/foo/bar/project`) and `M2` (defined in `/foo/bar/project/project`).
+
+The sbt build target for `M1` will have `A` and `B` as the defined targets and `M2` as the parent.
+Similarly, the sbt build target for `M2` will have `M1` as the defined target and no parent.
+
+Clients can use this information to reconstruct the tree of sbt meta builds. The
 `parent` information can be defined from `definedTargets` but it's provided by the server to
 simplify the data processing on the client side.
 

--- a/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -549,5 +549,5 @@ object ScalaPlatform {
     classpath: List[Uri],
     scalaBuildTarget: ScalaBuildTarget,
     parent: Option[BuildTargetIdentifier],
-    definedTargets: List[BuildTargetIdentifier],
+    children: List[BuildTargetIdentifier],
 )

--- a/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -544,9 +544,10 @@ object ScalaPlatform {
 )
 
 @JsonCodec final case class SbtBuildTarget(
-    parent: Option[BuildTargetIdentifier],
     sbtVersion: String,
     autoImports: List[String],
     classpath: List[Uri],
-    scalaBuildTarget: ScalaBuildTarget
+    scalaBuildTarget: ScalaBuildTarget,
+    parent: Option[BuildTargetIdentifier],
+    definedTargets: List[Json],
 )

--- a/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -549,5 +549,5 @@ object ScalaPlatform {
     classpath: List[Uri],
     scalaBuildTarget: ScalaBuildTarget,
     parent: Option[BuildTargetIdentifier],
-    definedTargets: List[Json],
+    definedTargets: List[BuildTargetIdentifier],
 )

--- a/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -35,7 +35,7 @@ trait BuildTarget {
         "buildTarget/dependencySources")
   object resources
       extends Endpoint[DependencySourcesParams, DependencySourcesResult](
-        "buildTarget/dependencySources")
+        "buildTarget/resources")
 
   // Scala specific endpoints
   object scalacOptions


### PR DESCRIPTION
This information is critical to tie together sbt build targets to a
series of scala projects and to reconstruct the sbt meta build graph.

It also fixes a typo in the name of the function for
`dependencyResources` and clarifies the spec of build target identifier.