### PR TITLE
s/scalaJars/jars/

### DIFF
--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -1047,9 +1047,9 @@ trait ScalaBuildTarget {
 
   /** The target platform for this target */
   def platform: Int
-  
-  /** A sequence of Scala jars. */
-  def scalaJars: List[String]
+
+  /** A sequence of Scala jars such as scala-library, scala-compiler and scala-reflect. */
+  def jars: List[String]
 }
 
 object ScalaPlatform {


### PR DESCRIPTION
To synchronize the spec with the bsp implementation. Stricly speaking we
should rename the implementation but that would break the existing
bloop/intellij users.