### PR TITLE
Implement bsp4j module based on org.eclipse.lsp4j.jsonrpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,29 @@
-.idea
-bin/.coursier
-bin/.scalafmt*
+*.class
+*.log
 
-# Required because these are the proxies for the sourcedeps
-.bridge
-.zinc
-.nailgun
-
-# zinc uses this local cache for publishing stuff
-.ivy2/
-
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
 target/
-*.config
-test-config.sbt
-test
-base-directory
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+.idea
+
+# ENSIME specific
+.ensime_cache/
+.ensime
+
+node_modules
+
+out/
+
+*._trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ stages:
 jobs:
   include:
     script:
-      - sbt test
+      - sbt test bsp4j/test
 
 cache:
   directories:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Updating bsp4j `*.xtend` files
+
+Whenever `*.xtend` files are updated you need to manually re-generate Java
+source files with the `sbt bsp4j/xtend` task.  For example, while iterating on
+changes in bsp4j you can use
+
+```
+sbt
+> ~; bsp4j/xtend ; bsp4j/compile
+```
+

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClient.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClient.java
@@ -8,16 +8,16 @@ import java.util.concurrent.CompletableFuture;
 public interface BuildClient {
 
     @JsonNotification("build/showMessage")
-    void showMessage(ShowMessageParams params);
+    void onShowMessage(ShowMessageParams params);
 
     @JsonNotification("build/logMessage")
-    void logMessage(LogMessageParams params);
+    void onLogMessage(LogMessageParams params);
 
     @JsonNotification("build/publishDiagnostics")
-    void publishDiagnostics(PublishDiagnosticsParams params);
+    void onPublishDiagnostics(PublishDiagnosticsParams params);
 
     @JsonNotification("buildTarget/didChange")
-    void didChangeBuildTarget(DidChangeBuildTarget params);
+    void onBuildTargetChanged(DidChangeBuildTarget params);
 
     @JsonRequest("build/registerFileWatcher")
     CompletableFuture<RegisterFileWatcherResult> registerFileWatcher(RegisterFileWatcherParams params);
@@ -26,9 +26,9 @@ public interface BuildClient {
     CompletableFuture<CancelFileWatcherResult> cancelFileWatcher(CancelFileWatcherParams params);
 
     @JsonNotification("buildTarget/compileReport")
-    void compileReport(CompileReport params);
+    void onCompileReport(CompileReport params);
 
-    default void connect(BuildServer server) {
+    default void onConnectWithServer(BuildServer server) {
 
     }
 

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClient.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClient.java
@@ -8,25 +8,25 @@ import java.util.concurrent.CompletableFuture;
 public interface BuildClient {
 
     @JsonNotification("build/showMessage")
-    void onShowMessage(ShowMessageParams params);
+    void onBuildShowMessage(ShowMessageParams params);
 
     @JsonNotification("build/logMessage")
-    void onLogMessage(LogMessageParams params);
+    void onBuildLogMessage(LogMessageParams params);
 
     @JsonNotification("build/publishDiagnostics")
-    void onPublishDiagnostics(PublishDiagnosticsParams params);
+    void onBuildPublishDiagnostics(PublishDiagnosticsParams params);
 
     @JsonNotification("buildTarget/didChange")
-    void onBuildTargetChanged(DidChangeBuildTarget params);
+    void onBuildTargetDidChange(DidChangeBuildTarget params);
 
     @JsonRequest("build/registerFileWatcher")
-    CompletableFuture<RegisterFileWatcherResult> registerFileWatcher(RegisterFileWatcherParams params);
+    CompletableFuture<RegisterFileWatcherResult> buildRegisterFileWatcher(RegisterFileWatcherParams params);
 
     @JsonRequest("build/cancelFileWatcher")
-    CompletableFuture<CancelFileWatcherResult> cancelFileWatcher(CancelFileWatcherParams params);
+    CompletableFuture<CancelFileWatcherResult> buildCancelFileWatcher(CancelFileWatcherParams params);
 
     @JsonNotification("buildTarget/compileReport")
-    void onCompileReport(CompileReport params);
+    void onBuildTargetCompileReport(CompileReport params);
 
     default void onConnectWithServer(BuildServer server) {
 

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClient.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildClient.java
@@ -1,0 +1,35 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface BuildClient {
+
+    @JsonNotification("build/showMessage")
+    void showMessage(ShowMessageParams params);
+
+    @JsonNotification("build/logMessage")
+    void logMessage(LogMessageParams params);
+
+    @JsonNotification("build/publishDiagnostics")
+    void publishDiagnostics(PublishDiagnosticsParams params);
+
+    @JsonNotification("buildTarget/didChange")
+    void didChangeBuildTarget(DidChangeBuildTarget params);
+
+    @JsonRequest("build/registerFileWatcher")
+    CompletableFuture<RegisterFileWatcherResult> registerFileWatcher(RegisterFileWatcherParams params);
+
+    @JsonRequest("build/cancelFileWatcher")
+    CompletableFuture<CancelFileWatcherResult> cancelFileWatcher(CancelFileWatcherParams params);
+
+    @JsonNotification("buildTarget/compileReport")
+    void compileReport(CompileReport params);
+
+    default void connect(BuildServer server) {
+
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -1,0 +1,53 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface BuildServer {
+
+    @JsonRequest("build/initialize")
+    CompletableFuture<InitializeBuildResult> initialize(InitializeBuildParams params);
+
+    @JsonNotification("build/initialized")
+    void initialized();
+
+    @JsonRequest("build/shutdown")
+    CompletableFuture<Object> shutdown();
+
+    @JsonNotification("build/exit")
+    void exit();
+
+    @JsonRequest("workspace/buildTargets")
+    CompletableFuture<WorkspaceBuildTargetsResult> workspaceBuildTargets();
+
+    @JsonNotification("build/didChangeWatchedFiles")
+    void didChangeWatchedFiles(DidChangeWatchedFiles params);
+
+    @JsonRequest("buildTarget/textDocuments")
+    CompletableFuture<BuildTargetTextDocumentsResult> buildTargetTextDocuments(BuildTargetTextDocumentsParams params);
+
+    @JsonRequest("textDocuments/buildTargets")
+    CompletableFuture<TextDocumentBuildTargetsResult> textDocumentBuildTargets(TextDocumentBuildTargetsParams params);
+
+    @JsonRequest("buildTarget/dependencySources")
+    CompletableFuture<DependencySourcesResult> buildTargetDependencySources(DependencySourcesParams params);
+
+    @JsonRequest("buildTarget/resources")
+    CompletableFuture<ResourcesResult> buildTargetResources(ResourcesParams params);
+
+    @JsonRequest("buildTarget/compile")
+    CompletableFuture<CompileResult> buildTargetCompile(CompileParams params);
+
+    @JsonRequest("buildTarget/test")
+    CompletableFuture<TestResult> buildTargetTest(TestParams params);
+
+    @JsonRequest("buildTarget/run")
+    CompletableFuture<RunResult> buildTargetRun(RunParams params);
+
+    default void connect(BuildClient server) {
+
+    }
+}
+

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -11,42 +11,42 @@ public interface BuildServer {
     CompletableFuture<InitializeBuildResult> initialize(InitializeBuildParams params);
 
     @JsonNotification("build/initialized")
-    void initialized();
+    void onInitialized();
 
     @JsonRequest("build/shutdown")
     CompletableFuture<Object> shutdown();
 
     @JsonNotification("build/exit")
-    void exit();
+    void onExit();
 
     @JsonRequest("workspace/buildTargets")
-    CompletableFuture<WorkspaceBuildTargetsResult> workspaceBuildTargets();
+    CompletableFuture<WorkspaceBuildTargetsResult> listWorkspaceBuildTargets();
 
     @JsonNotification("build/didChangeWatchedFiles")
-    void didChangeWatchedFiles(DidChangeWatchedFiles params);
+    void onWatchedFileChanged(DidChangeWatchedFiles params);
 
     @JsonRequest("buildTarget/textDocuments")
-    CompletableFuture<BuildTargetTextDocumentsResult> buildTargetTextDocuments(BuildTargetTextDocumentsParams params);
+    CompletableFuture<BuildTargetTextDocumentsResult> listBuildTargetTextDocuments(BuildTargetTextDocumentsParams params);
 
     @JsonRequest("textDocuments/buildTargets")
-    CompletableFuture<TextDocumentBuildTargetsResult> textDocumentBuildTargets(TextDocumentBuildTargetsParams params);
+    CompletableFuture<TextDocumentBuildTargetsResult> listTextDocumentBuildTargets(TextDocumentBuildTargetsParams params);
 
     @JsonRequest("buildTarget/dependencySources")
-    CompletableFuture<DependencySourcesResult> buildTargetDependencySources(DependencySourcesParams params);
+    CompletableFuture<DependencySourcesResult> listBuildTargetDependencySources(DependencySourcesParams params);
 
     @JsonRequest("buildTarget/resources")
-    CompletableFuture<ResourcesResult> buildTargetResources(ResourcesParams params);
+    CompletableFuture<ResourcesResult> listBuildTargetResources(ResourcesParams params);
 
     @JsonRequest("buildTarget/compile")
-    CompletableFuture<CompileResult> buildTargetCompile(CompileParams params);
+    CompletableFuture<CompileResult> compileBuildTarget(CompileParams params);
 
     @JsonRequest("buildTarget/test")
-    CompletableFuture<TestResult> buildTargetTest(TestParams params);
+    CompletableFuture<TestResult> testBuildTarget(TestParams params);
 
     @JsonRequest("buildTarget/run")
-    CompletableFuture<RunResult> buildTargetRun(RunParams params);
+    CompletableFuture<RunResult> runBuildTarget(RunParams params);
 
-    default void connect(BuildClient server) {
+    default void onConnectWithClient(BuildClient server) {
 
     }
 }

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -8,43 +8,43 @@ import java.util.concurrent.CompletableFuture;
 public interface BuildServer {
 
     @JsonRequest("build/initialize")
-    CompletableFuture<InitializeBuildResult> initialize(InitializeBuildParams params);
+    CompletableFuture<InitializeBuildResult> buildInitialize(InitializeBuildParams params);
 
     @JsonNotification("build/initialized")
-    void onInitialized();
+    void onBuildInitialized();
 
     @JsonRequest("build/shutdown")
-    CompletableFuture<Object> shutdown();
+    CompletableFuture<Object> buildShutdown();
 
     @JsonNotification("build/exit")
-    void onExit();
+    void onBuildExit();
 
     @JsonRequest("workspace/buildTargets")
-    CompletableFuture<WorkspaceBuildTargetsResult> listWorkspaceBuildTargets();
+    CompletableFuture<WorkspaceBuildTargetsResult> workspaceBuildTargets();
 
     @JsonNotification("build/didChangeWatchedFiles")
-    void onWatchedFileChanged(DidChangeWatchedFiles params);
+    void onBuildDidChangeWatchedFiles(DidChangeWatchedFiles params);
 
     @JsonRequest("buildTarget/textDocuments")
-    CompletableFuture<BuildTargetTextDocumentsResult> listBuildTargetTextDocuments(BuildTargetTextDocumentsParams params);
+    CompletableFuture<BuildTargetTextDocumentsResult> buildTargetTextDocuments(BuildTargetTextDocumentsParams params);
 
-    @JsonRequest("textDocuments/buildTargets")
-    CompletableFuture<TextDocumentBuildTargetsResult> listTextDocumentBuildTargets(TextDocumentBuildTargetsParams params);
+    @JsonRequest("textDocument/buildTargets")
+    CompletableFuture<TextDocumentBuildTargetsResult> textDocumentBuildTargets(TextDocumentBuildTargetsParams params);
 
     @JsonRequest("buildTarget/dependencySources")
-    CompletableFuture<DependencySourcesResult> listBuildTargetDependencySources(DependencySourcesParams params);
+    CompletableFuture<DependencySourcesResult> buildTargetDependencySources(DependencySourcesParams params);
 
     @JsonRequest("buildTarget/resources")
-    CompletableFuture<ResourcesResult> listBuildTargetResources(ResourcesParams params);
+    CompletableFuture<ResourcesResult> buildTargetResources(ResourcesParams params);
 
     @JsonRequest("buildTarget/compile")
-    CompletableFuture<CompileResult> compileBuildTarget(CompileParams params);
+    CompletableFuture<CompileResult> buildTargetCompile(CompileParams params);
 
     @JsonRequest("buildTarget/test")
-    CompletableFuture<TestResult> testBuildTarget(TestParams params);
+    CompletableFuture<TestResult> buildTargetTest(TestParams params);
 
     @JsonRequest("buildTarget/run")
-    CompletableFuture<RunResult> runBuildTarget(RunParams params);
+    CompletableFuture<RunResult> buildTargetRun(RunParams params);
 
     default void onConnectWithClient(BuildClient server) {
 

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetEventKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetEventKind.java
@@ -1,0 +1,27 @@
+package ch.epfl.scala.bsp4j;
+
+public enum BuildTargetEventKind {
+
+    CREATED(1),
+    CHANGED(2),
+    DELETED(3);
+
+    private final int value;
+
+    BuildTargetEventKind(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static BuildTargetEventKind forValue(int value) {
+        BuildTargetEventKind[] allValues = BuildTargetEventKind.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildTargetKind.java
@@ -1,0 +1,29 @@
+package ch.epfl.scala.bsp4j;
+
+public enum BuildTargetKind {
+
+    LIBRARY(1),
+    TEST(2),
+    APP(3),
+    INTEGRATION_TEST(4),
+    BENCH(5);
+
+    private final int value;
+
+    BuildTargetKind(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static BuildTargetKind forValue(int value) {
+        BuildTargetKind[] allValues = BuildTargetKind.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DiagnosticSeverity.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/DiagnosticSeverity.java
@@ -1,0 +1,27 @@
+package ch.epfl.scala.bsp4j;
+
+public enum DiagnosticSeverity {
+
+    ERROR(1),
+    WARNING(2),
+    INFORMATION(3),
+    HINT(4);
+
+    private final int value;
+
+    DiagnosticSeverity(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static DiagnosticSeverity forValue(int value) {
+        DiagnosticSeverity[] allValues = DiagnosticSeverity.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/FileChangeType.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/FileChangeType.java
@@ -1,0 +1,27 @@
+package ch.epfl.scala.bsp4j;
+
+public enum FileChangeType {
+
+    CREATED(1),
+    CHANGED(2),
+    DELETED(3);
+
+    private final int value;
+
+    FileChangeType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static FileChangeType forValue(int value) {
+        FileChangeType[] allValues = FileChangeType.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/MessageType.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/MessageType.java
@@ -1,0 +1,28 @@
+package ch.epfl.scala.bsp4j;
+
+public enum MessageType {
+
+    ERROR(1),
+    WARNING(2),
+    INFORMATION(3),
+    LOG(4);
+
+    private final int value;
+
+    MessageType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static MessageType forValue(int value) {
+        MessageType[] allValues = MessageType.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -1,0 +1,459 @@
+package ch.epfl.scala.bsp4j
+
+import java.util.List
+import com.google.gson.annotations.JsonAdapter
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.lsp4j.generator.JsonRpcData
+
+@JsonRpcData
+class TextDocumentIdentifier {
+
+  @NonNull String uri
+
+  new (@NonNull String uri) {
+    this.uri = uri
+  }
+}
+
+@JsonRpcData
+class BuildTargetIdentifier {
+
+  @NonNull String uri
+
+  new (@NonNull String uri) {
+    this.uri = uri
+  }
+}
+
+@JsonRpcData
+class BuildTargetCapabilities {
+
+  @NonNull Boolean canCompile
+  @NonNull Boolean canTest
+  @NonNull Boolean canRun
+
+  new (Boolean canCompile, Boolean canTest, Boolean canRun) {
+    this.canCompile = canCompile
+    this.canTest = canTest
+    this.canRun = canRun
+  }
+}
+
+@JsonRpcData
+class BuildTarget {
+
+  @NonNull BuildTargetIdentifier id
+  String displayName
+  @NonNull BuildTargetKind kind
+  List<String> languageIds
+  List<BuildTargetIdentifier> dependencies
+  @NonNull BuildTargetCapabilities capabilities
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+
+  new (@NonNull BuildTargetIdentifier id, @NonNull BuildTargetKind kind, @NonNull BuildTargetCapabilities capabilities) {
+    this.id = id
+    this.kind = kind
+    this.capabilities = capabilities
+  }
+}
+
+@JsonRpcData
+class InitializeBuildParams {
+  @NonNull String rootUri
+  @NonNull BuildClientCapabilities capabilities
+
+  new(@NonNull String rootUri, @NonNull BuildClientCapabilities capabilities) {
+    this.rootUri = rootUri
+    this.capabilities = capabilities
+  }
+}
+
+
+@JsonRpcData
+class BuildClientCapabilities {
+  @NonNull List<String> languageIds
+  @NonNull Boolean providesFileWatching
+  new(@NonNull List<String> languageIds, @NonNull Boolean providesFileWatching) {
+    this.languageIds = languageIds
+    this.providesFileWatching = providesFileWatching
+  }
+}
+
+
+@JsonRpcData
+class CompileProvider {
+  List<String> languageIds
+}
+
+@JsonRpcData
+class TestProvider {
+  List<String> languageIds
+}
+
+@JsonRpcData
+class RunProvider {
+  List<String> languageIds
+}
+
+@JsonRpcData
+class BuildServerCapabilities {
+  CompileProvider compileProvider
+  TestProvider testProvider
+  RunProvider runProvider
+  Boolean textDocumentBuildTargetsProvider
+  Boolean dependencySourcesProvider
+  Boolean resourcesProvider
+  Boolean buildTargetChangedProvider
+}
+
+@JsonRpcData
+class InitializeBuildResult {
+  @NonNull BuildServerCapabilities capabilities
+  new(@NonNull BuildServerCapabilities capabilities) {
+    this.capabilities = capabilities
+  }
+}
+
+@JsonRpcData
+class TaskId {
+  @NonNull String id
+  String parent
+  new(@NonNull String id) {
+    this.id = id
+  }
+}
+
+
+@JsonRpcData
+class ShowMessageParams {
+  @NonNull MessageType type
+  TaskId task
+  String originId
+  @NonNull String message
+  new(@NonNull MessageType type, @NonNull String message) {
+    this.type = type
+    this.message = message
+  }
+}
+
+@JsonRpcData
+class LogMessageParams {
+  @NonNull MessageType type
+  TaskId task
+  String originId
+  @NonNull String message
+  new(@NonNull MessageType type, @NonNull String message) {
+    this.type = type
+    this.message = message
+  }
+}
+
+@JsonRpcData
+class Position {
+  @NonNull Integer line
+  @NonNull Integer character
+  new(@NonNull Integer line, @NonNull Integer character) {
+    this.line = line
+    this.character = character
+  }
+}
+
+@JsonRpcData
+class Range {
+  @NonNull Position start
+  @NonNull Position end
+  new(@NonNull Position start, @NonNull Position end) {
+    this.start = start
+    this.end = end
+  }
+}
+
+@JsonRpcData
+class Location {
+  @NonNull String uri
+  @NonNull Range range
+  new(@NonNull String uri, @NonNull Range range) {
+    this.uri = uri
+    this.range = range
+  }
+}
+
+@JsonRpcData
+class DiagnosticRelatedInformation {
+  @NonNull Location location
+  @NonNull String message
+  new(@NonNull Location location, @NonNull String message) {
+    this.location = location
+    this.message = message
+  }
+}
+
+@JsonRpcData
+class Diagnostic {
+  @NonNull Range range
+  DiagnosticSeverity severity
+  String code
+  String source
+  @NonNull String message
+  DiagnosticRelatedInformation relatedInformation
+  new(@NonNull Range range, @NonNull String message) {
+    this.range = range
+    this.message = message
+  }
+}
+
+@JsonRpcData
+class PublishDiagnosticsParams {
+  @NonNull String uri
+  String originId
+  List<Diagnostic> diagnostics
+  new(@NonNull String uri) {
+    this.uri = uri
+  }
+}
+
+@JsonRpcData
+class WorkspaceBuildTargetsResult {
+  List<BuildTarget> targets
+  new(@NonNull List<BuildTarget> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class RegisterFileWatcherParams {
+  @NonNull String globPattern
+  WatchKind kind
+  new(@NonNull String globPattern) {
+    this.globPattern = globPattern
+  }
+}
+
+@JsonRpcData
+class RegisterFileWatcherResult {
+  @NonNull String id
+  new(@NonNull String id) {
+    this.id = id
+  }
+}
+
+@JsonRpcData
+class DidChangeWatchedFiles {
+  List<FileEvent> changes
+  new(@NonNull List<FileEvent> changes) {
+    this.changes = changes
+  }
+}
+
+@JsonRpcData
+class FileEvent {
+  @NonNull String uri
+  @NonNull FileChangeType type
+  new(@NonNull String uri, @NonNull FileChangeType type) {
+    this.uri = uri
+    this.type = type
+  }
+}
+
+@JsonRpcData
+class CancelFileWatcherParams {
+  @NonNull String id
+  new(@NonNull String id) {
+    this.id = id
+  }
+}
+
+@JsonRpcData
+class CancelFileWatcherResult {
+  @NonNull Boolean cancelled
+  new(@NonNull Boolean cancelled) {
+    this.cancelled = cancelled
+  }
+}
+
+@JsonRpcData
+class DidChangeBuildTarget {
+  @NonNull List<BuildTargetEvent> changes
+  new(@NonNull List<BuildTargetEvent> changes) {
+    this.changes = changes
+  }
+}
+
+@JsonRpcData
+class BuildTargetEvent {
+  @NonNull String uri
+  BuildTargetEventKind kind
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+  new(@NonNull String uri) {
+    this.uri = uri
+  }
+}
+
+@JsonRpcData
+class BuildTargetTextDocumentsParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class BuildTargetTextDocumentsResult {
+  @NonNull List<TextDocumentIdentifier> textDocuments
+  new(@NonNull List<TextDocumentIdentifier> textDocuments) {
+    this.textDocuments = textDocuments
+  }
+}
+
+@JsonRpcData
+class TextDocumentBuildTargetsParams {
+  @NonNull List<TextDocumentIdentifier> textDocuments
+  new(@NonNull List<TextDocumentIdentifier> textDocuments) {
+    this.textDocuments = textDocuments
+  }
+}
+
+@JsonRpcData
+class TextDocumentBuildTargetsResult {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class DependencySourcesParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class DependencySourcesResult {
+  @NonNull List<DependencySourcesItem> items
+  new(@NonNull List<DependencySourcesItem> items) {
+    this.items = items
+  }
+}
+@JsonRpcData
+class DependencySourcesItem {
+  @NonNull List<BuildTargetIdentifier> targets
+  @NonNull List<String> sources
+  new(@NonNull List<BuildTargetIdentifier> targets, @NonNull List<String> sources) {
+    this.targets = targets
+    this.sources = sources
+  }
+}
+
+@JsonRpcData
+class ResourcesParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class ResourcesResult {
+  @NonNull List<ResourcesItem> items
+  new(@NonNull List<ResourcesItem> items) {
+    this.items = items
+  }
+}
+@JsonRpcData
+class ResourcesItem {
+  @NonNull List<BuildTargetIdentifier> targets
+  @NonNull List<String> resources
+  new(@NonNull List<BuildTargetIdentifier> targets, @NonNull List<String> resources) {
+    this.targets = targets
+    this.resources = resources
+  }
+}
+
+@JsonRpcData
+class CompileParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  String originId
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object arguments
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class CompileResult {
+  String originId
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+}
+
+@JsonRpcData
+class CompileReport {
+  @NonNull BuildTargetIdentifier target
+  String originId
+  @NonNull Integer errors
+  @NonNull Integer warnings
+  Long time
+  new(@NonNull BuildTargetIdentifier target, Integer errors, Integer warnings) {
+    this.target = target
+    this.errors = errors
+    this.warnings = warnings
+  }
+}
+
+@JsonRpcData
+class TestParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  String originId
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object arguments
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class TestResult {
+  String originId
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+}
+
+@JsonRpcData
+class TestReport {
+  @NonNull BuildTargetIdentifier target
+  String originId
+  @NonNull Integer passed
+  @NonNull Integer failed
+  @NonNull Integer ignored
+  @NonNull Integer cancelled
+  @NonNull Integer skipped
+  Long time
+  new(@NonNull BuildTargetIdentifier target, Integer passed, Integer failed, Integer ignored,
+      Integer cancelled, Integer skipped) {
+    this.target = target
+    this.passed = passed
+    this.failed = failed
+    this.ignored = ignored
+    this.cancelled = cancelled
+    this.skipped = skipped
+  }
+}
+
+@JsonRpcData
+class RunParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  String originId
+  @JsonAdapter(JsonElementTypeAdapter.Factory) Object arguments
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class RunResult {
+  String originId
+  @NonNull StatusCode statusCode
+  new(@NonNull StatusCode statusCode) {
+    this.statusCode = statusCode
+  }
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/SbtExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/SbtExtension.xtend
@@ -1,0 +1,23 @@
+package ch.epfl.scala.bsp4j
+
+import java.util.List
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.lsp4j.generator.JsonRpcData
+
+@JsonRpcData
+class SbtBuildTarget {
+  @NonNull String sbtVersion
+  @NonNull List<String> autoImports
+  @NonNull List<String> classpath
+  @NonNull ScalaBuildTarget scalaBuildTarget
+  BuildTargetIdentifier parent
+  @NonNull List<BuildTargetIdentifier> children
+  new(@NonNull String sbtVersion, @NonNull List<String> autoImports, @NonNull List<String> classpath,
+      @NonNull ScalaBuildTarget scalaBuildTarget, @NonNull List<BuildTargetIdentifier> children) {
+    this.sbtVersion = sbtVersion
+    this.autoImports = autoImports
+    this.classpath = classpath
+    this.scalaBuildTarget = scalaBuildTarget
+    this.children = children
+  }
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaBuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaBuildServer.java
@@ -1,0 +1,17 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface ScalaBuildServer {
+
+    @JsonRequest("buildTarget/scalacOptions")
+    CompletableFuture<ScalacOptionsResult> buildTargetScalacOptions(ScalacOptionsParams params);
+
+    @JsonRequest("buildTarget/scalaTestClasses")
+    CompletableFuture<ScalaTestClassesResult> buildTargetScalaTestClasses(ScalaTestClassesParams params);
+
+    @JsonRequest("buildTarget/scalaMainClasses")
+    CompletableFuture<ScalaMainClassesResult> buildTargetScalaMainClasses(ScalaMainClassesParams params);
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaExtension.xtend
@@ -1,0 +1,114 @@
+package ch.epfl.scala.bsp4j
+
+import java.util.List
+import com.google.gson.annotations.SerializedName
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.lsp4j.generator.JsonRpcData
+
+@JsonRpcData
+class ScalaBuildTarget {
+  @NonNull String scalaOrganization
+  @NonNull String scalaVersion
+  @NonNull String scalaBinaryVersion
+  @NonNull ScalaPlatform platform
+  @NonNull List<String> jars
+  new(@NonNull String scalaOrganization, @NonNull String scalaVersion, @NonNull String scalaBinaryVersion,
+      @NonNull ScalaPlatform platform, @NonNull List<String> jars) {
+    this.scalaOrganization = scalaOrganization
+    this.scalaVersion = scalaVersion
+    this.scalaBinaryVersion = scalaBinaryVersion
+    this.platform = platform
+    this.jars = jars
+  }
+}
+
+@JsonRpcData
+class ScalacOptionsParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class ScalacOptionsResult {
+  @NonNull List<ScalacOptionsItem> items
+  new(@NonNull List<ScalacOptionsItem> items) {
+    this.items = items
+  }
+}
+
+@JsonRpcData
+class ScalacOptionsItem {
+  @NonNull BuildTargetIdentifier target
+  @NonNull List<String> options
+  @NonNull List<String> classpath
+  @NonNull String classDirectory
+  new(@NonNull BuildTargetIdentifier target, @NonNull List<String> options, @NonNull List<String> classpath,
+      @NonNull String classDirectory) {
+    this.target = target
+    this.options = options
+    this.classpath = classpath
+    this.classDirectory = classDirectory
+   }
+}
+
+@JsonRpcData
+class ScalaTestClassesParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  String originId
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class ScalaTestClassesResult {
+  @NonNull List<ScalaTestClassesItem> items
+  new(@NonNull List<ScalaTestClassesItem> items) {
+    this.items = items
+  }
+}
+
+@JsonRpcData
+class ScalaTestClassesItem {
+  @NonNull BuildTargetIdentifier target
+  @NonNull List<String> classes
+  new(@NonNull BuildTargetIdentifier target, @NonNull List<String> classes) {
+    this.target = target
+    this.classes = classes
+  }
+}
+
+@JsonRpcData
+class ScalaMainClassesParams {
+  @NonNull List<BuildTargetIdentifier> targets
+  String originId
+  new(@NonNull List<BuildTargetIdentifier> targets) {
+    this.targets = targets
+  }
+}
+
+@JsonRpcData
+class ScalaMainClassesResult {
+  @NonNull List<ScalaMainClassesItem> items
+  new(@NonNull List<ScalaMainClassesItem> items) {
+    this.items = items
+  }
+}
+
+@JsonRpcData
+class ScalaMainClassesItem {
+  @NonNull BuildTargetIdentifier target
+  @NonNull List<ScalaMainClass> classes
+  new(@NonNull BuildTargetIdentifier target, @NonNull List<ScalaMainClass> classes) {
+    this.target = target
+    this.classes = classes
+  }
+}
+@JsonRpcData
+class ScalaMainClass {
+  @NonNull @SerializedName("class") String className
+  @NonNull List<String> arguments
+  @NonNull List<String> jvmOptions
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaPlatform.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/ScalaPlatform.java
@@ -1,0 +1,27 @@
+package ch.epfl.scala.bsp4j;
+
+public enum ScalaPlatform {
+
+    JVM(1),
+    JS(2),
+    NATIVE(3);
+
+    private final int value;
+
+    ScalaPlatform(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static ScalaPlatform forValue(int value) {
+        ScalaPlatform[] allValues = ScalaPlatform.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/StatusCode.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/StatusCode.java
@@ -1,0 +1,27 @@
+package ch.epfl.scala.bsp4j;
+
+public enum StatusCode {
+
+    OK(1),
+    ERROR(2),
+    CANCELLED(3);
+
+    private final int value;
+
+    StatusCode(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static StatusCode forValue(int value) {
+        StatusCode[] allValues = StatusCode.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/WatchKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/WatchKind.java
@@ -1,0 +1,27 @@
+package ch.epfl.scala.bsp4j;
+
+public enum WatchKind {
+
+    CREATE(1),
+    CHANGE(2),
+    DELETE(3);
+
+    private final int value;
+
+    WatchKind(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+
+    public static WatchKind forValue(int value) {
+        WatchKind[] allValues = WatchKind.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildClientCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildClientCapabilities.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildClientCapabilities {
+  @NonNull
+  private List<String> languageIds;
+  
+  @NonNull
+  private Boolean providesFileWatching;
+  
+  public BuildClientCapabilities(@NonNull final List<String> languageIds, @NonNull final Boolean providesFileWatching) {
+    this.languageIds = languageIds;
+    this.providesFileWatching = providesFileWatching;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+  
+  public void setLanguageIds(@NonNull final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+  
+  @Pure
+  @NonNull
+  public Boolean getProvidesFileWatching() {
+    return this.providesFileWatching;
+  }
+  
+  public void setProvidesFileWatching(@NonNull final Boolean providesFileWatching) {
+    this.providesFileWatching = providesFileWatching;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("languageIds", this.languageIds);
+    b.add("providesFileWatching", this.providesFileWatching);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildClientCapabilities other = (BuildClientCapabilities) obj;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    if (this.providesFileWatching == null) {
+      if (other.providesFileWatching != null)
+        return false;
+    } else if (!this.providesFileWatching.equals(other.providesFileWatching))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+    return prime * result + ((this.providesFileWatching== null) ? 0 : this.providesFileWatching.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -1,0 +1,163 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.CompileProvider;
+import ch.epfl.scala.bsp4j.RunProvider;
+import ch.epfl.scala.bsp4j.TestProvider;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildServerCapabilities {
+  private CompileProvider compileProvider;
+  
+  private TestProvider testProvider;
+  
+  private RunProvider runProvider;
+  
+  private Boolean textDocumentBuildTargetsProvider;
+  
+  private Boolean dependencySourcesProvider;
+  
+  private Boolean resourcesProvider;
+  
+  private Boolean buildTargetChangedProvider;
+  
+  @Pure
+  public CompileProvider getCompileProvider() {
+    return this.compileProvider;
+  }
+  
+  public void setCompileProvider(final CompileProvider compileProvider) {
+    this.compileProvider = compileProvider;
+  }
+  
+  @Pure
+  public TestProvider getTestProvider() {
+    return this.testProvider;
+  }
+  
+  public void setTestProvider(final TestProvider testProvider) {
+    this.testProvider = testProvider;
+  }
+  
+  @Pure
+  public RunProvider getRunProvider() {
+    return this.runProvider;
+  }
+  
+  public void setRunProvider(final RunProvider runProvider) {
+    this.runProvider = runProvider;
+  }
+  
+  @Pure
+  public Boolean getTextDocumentBuildTargetsProvider() {
+    return this.textDocumentBuildTargetsProvider;
+  }
+  
+  public void setTextDocumentBuildTargetsProvider(final Boolean textDocumentBuildTargetsProvider) {
+    this.textDocumentBuildTargetsProvider = textDocumentBuildTargetsProvider;
+  }
+  
+  @Pure
+  public Boolean getDependencySourcesProvider() {
+    return this.dependencySourcesProvider;
+  }
+  
+  public void setDependencySourcesProvider(final Boolean dependencySourcesProvider) {
+    this.dependencySourcesProvider = dependencySourcesProvider;
+  }
+  
+  @Pure
+  public Boolean getResourcesProvider() {
+    return this.resourcesProvider;
+  }
+  
+  public void setResourcesProvider(final Boolean resourcesProvider) {
+    this.resourcesProvider = resourcesProvider;
+  }
+  
+  @Pure
+  public Boolean getBuildTargetChangedProvider() {
+    return this.buildTargetChangedProvider;
+  }
+  
+  public void setBuildTargetChangedProvider(final Boolean buildTargetChangedProvider) {
+    this.buildTargetChangedProvider = buildTargetChangedProvider;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("compileProvider", this.compileProvider);
+    b.add("testProvider", this.testProvider);
+    b.add("runProvider", this.runProvider);
+    b.add("textDocumentBuildTargetsProvider", this.textDocumentBuildTargetsProvider);
+    b.add("dependencySourcesProvider", this.dependencySourcesProvider);
+    b.add("resourcesProvider", this.resourcesProvider);
+    b.add("buildTargetChangedProvider", this.buildTargetChangedProvider);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildServerCapabilities other = (BuildServerCapabilities) obj;
+    if (this.compileProvider == null) {
+      if (other.compileProvider != null)
+        return false;
+    } else if (!this.compileProvider.equals(other.compileProvider))
+      return false;
+    if (this.testProvider == null) {
+      if (other.testProvider != null)
+        return false;
+    } else if (!this.testProvider.equals(other.testProvider))
+      return false;
+    if (this.runProvider == null) {
+      if (other.runProvider != null)
+        return false;
+    } else if (!this.runProvider.equals(other.runProvider))
+      return false;
+    if (this.textDocumentBuildTargetsProvider == null) {
+      if (other.textDocumentBuildTargetsProvider != null)
+        return false;
+    } else if (!this.textDocumentBuildTargetsProvider.equals(other.textDocumentBuildTargetsProvider))
+      return false;
+    if (this.dependencySourcesProvider == null) {
+      if (other.dependencySourcesProvider != null)
+        return false;
+    } else if (!this.dependencySourcesProvider.equals(other.dependencySourcesProvider))
+      return false;
+    if (this.resourcesProvider == null) {
+      if (other.resourcesProvider != null)
+        return false;
+    } else if (!this.resourcesProvider.equals(other.resourcesProvider))
+      return false;
+    if (this.buildTargetChangedProvider == null) {
+      if (other.buildTargetChangedProvider != null)
+        return false;
+    } else if (!this.buildTargetChangedProvider.equals(other.buildTargetChangedProvider))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.compileProvider== null) ? 0 : this.compileProvider.hashCode());
+    result = prime * result + ((this.testProvider== null) ? 0 : this.testProvider.hashCode());
+    result = prime * result + ((this.runProvider== null) ? 0 : this.runProvider.hashCode());
+    result = prime * result + ((this.textDocumentBuildTargetsProvider== null) ? 0 : this.textDocumentBuildTargetsProvider.hashCode());
+    result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
+    result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());
+    return prime * result + ((this.buildTargetChangedProvider== null) ? 0 : this.buildTargetChangedProvider.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTarget.java
@@ -1,0 +1,180 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetCapabilities;
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.BuildTargetKind;
+import com.google.gson.annotations.JsonAdapter;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildTarget {
+  @NonNull
+  private BuildTargetIdentifier id;
+  
+  private String displayName;
+  
+  @NonNull
+  private BuildTargetKind kind;
+  
+  private List<String> languageIds;
+  
+  private List<BuildTargetIdentifier> dependencies;
+  
+  @NonNull
+  private BuildTargetCapabilities capabilities;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
+  
+  public BuildTarget(@NonNull final BuildTargetIdentifier id, @NonNull final BuildTargetKind kind, @NonNull final BuildTargetCapabilities capabilities) {
+    this.id = id;
+    this.kind = kind;
+    this.capabilities = capabilities;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getId() {
+    return this.id;
+  }
+  
+  public void setId(@NonNull final BuildTargetIdentifier id) {
+    this.id = id;
+  }
+  
+  @Pure
+  public String getDisplayName() {
+    return this.displayName;
+  }
+  
+  public void setDisplayName(final String displayName) {
+    this.displayName = displayName;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetKind getKind() {
+    return this.kind;
+  }
+  
+  public void setKind(@NonNull final BuildTargetKind kind) {
+    this.kind = kind;
+  }
+  
+  @Pure
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+  
+  public void setLanguageIds(final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+  
+  @Pure
+  public List<BuildTargetIdentifier> getDependencies() {
+    return this.dependencies;
+  }
+  
+  public void setDependencies(final List<BuildTargetIdentifier> dependencies) {
+    this.dependencies = dependencies;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetCapabilities getCapabilities() {
+    return this.capabilities;
+  }
+  
+  public void setCapabilities(@NonNull final BuildTargetCapabilities capabilities) {
+    this.capabilities = capabilities;
+  }
+  
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("id", this.id);
+    b.add("displayName", this.displayName);
+    b.add("kind", this.kind);
+    b.add("languageIds", this.languageIds);
+    b.add("dependencies", this.dependencies);
+    b.add("capabilities", this.capabilities);
+    b.add("data", this.data);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildTarget other = (BuildTarget) obj;
+    if (this.id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!this.id.equals(other.id))
+      return false;
+    if (this.displayName == null) {
+      if (other.displayName != null)
+        return false;
+    } else if (!this.displayName.equals(other.displayName))
+      return false;
+    if (this.kind == null) {
+      if (other.kind != null)
+        return false;
+    } else if (!this.kind.equals(other.kind))
+      return false;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    if (this.dependencies == null) {
+      if (other.dependencies != null)
+        return false;
+    } else if (!this.dependencies.equals(other.dependencies))
+      return false;
+    if (this.capabilities == null) {
+      if (other.capabilities != null)
+        return false;
+    } else if (!this.capabilities.equals(other.capabilities))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.id== null) ? 0 : this.id.hashCode());
+    result = prime * result + ((this.displayName== null) ? 0 : this.displayName.hashCode());
+    result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+    result = prime * result + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+    result = prime * result + ((this.dependencies== null) ? 0 : this.dependencies.hashCode());
+    result = prime * result + ((this.capabilities== null) ? 0 : this.capabilities.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetCapabilities.java
@@ -1,0 +1,101 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildTargetCapabilities {
+  @NonNull
+  private Boolean canCompile;
+  
+  @NonNull
+  private Boolean canTest;
+  
+  @NonNull
+  private Boolean canRun;
+  
+  public BuildTargetCapabilities(final Boolean canCompile, final Boolean canTest, final Boolean canRun) {
+    this.canCompile = canCompile;
+    this.canTest = canTest;
+    this.canRun = canRun;
+  }
+  
+  @Pure
+  @NonNull
+  public Boolean getCanCompile() {
+    return this.canCompile;
+  }
+  
+  public void setCanCompile(@NonNull final Boolean canCompile) {
+    this.canCompile = canCompile;
+  }
+  
+  @Pure
+  @NonNull
+  public Boolean getCanTest() {
+    return this.canTest;
+  }
+  
+  public void setCanTest(@NonNull final Boolean canTest) {
+    this.canTest = canTest;
+  }
+  
+  @Pure
+  @NonNull
+  public Boolean getCanRun() {
+    return this.canRun;
+  }
+  
+  public void setCanRun(@NonNull final Boolean canRun) {
+    this.canRun = canRun;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("canCompile", this.canCompile);
+    b.add("canTest", this.canTest);
+    b.add("canRun", this.canRun);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildTargetCapabilities other = (BuildTargetCapabilities) obj;
+    if (this.canCompile == null) {
+      if (other.canCompile != null)
+        return false;
+    } else if (!this.canCompile.equals(other.canCompile))
+      return false;
+    if (this.canTest == null) {
+      if (other.canTest != null)
+        return false;
+    } else if (!this.canTest.equals(other.canTest))
+      return false;
+    if (this.canRun == null) {
+      if (other.canRun != null)
+        return false;
+    } else if (!this.canRun.equals(other.canRun))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.canCompile== null) ? 0 : this.canCompile.hashCode());
+    result = prime * result + ((this.canTest== null) ? 0 : this.canTest.hashCode());
+    return prime * result + ((this.canRun== null) ? 0 : this.canRun.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetEvent.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetEvent.java
@@ -1,0 +1,99 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetEventKind;
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildTargetEvent {
+  @NonNull
+  private String uri;
+  
+  private BuildTargetEventKind kind;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
+  
+  public BuildTargetEvent(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  public BuildTargetEventKind getKind() {
+    return this.kind;
+  }
+  
+  public void setKind(final BuildTargetEventKind kind) {
+    this.kind = kind;
+  }
+  
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    b.add("kind", this.kind);
+    b.add("data", this.data);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildTargetEvent other = (BuildTargetEvent) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.kind == null) {
+      if (other.kind != null)
+        return false;
+    } else if (!this.kind.equals(other.kind))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetIdentifier.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetIdentifier.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildTargetIdentifier {
+  @NonNull
+  private String uri;
+  
+  public BuildTargetIdentifier(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildTargetIdentifier other = (BuildTargetIdentifier) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.uri== null) ? 0 : this.uri.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetTextDocumentsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetTextDocumentsParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildTargetTextDocumentsParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public BuildTargetTextDocumentsParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildTargetTextDocumentsParams other = (BuildTargetTextDocumentsParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetTextDocumentsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildTargetTextDocumentsResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.TextDocumentIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class BuildTargetTextDocumentsResult {
+  @NonNull
+  private List<TextDocumentIdentifier> textDocuments;
+  
+  public BuildTargetTextDocumentsResult(@NonNull final List<TextDocumentIdentifier> textDocuments) {
+    this.textDocuments = textDocuments;
+  }
+  
+  @Pure
+  @NonNull
+  public List<TextDocumentIdentifier> getTextDocuments() {
+    return this.textDocuments;
+  }
+  
+  public void setTextDocuments(@NonNull final List<TextDocumentIdentifier> textDocuments) {
+    this.textDocuments = textDocuments;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("textDocuments", this.textDocuments);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BuildTargetTextDocumentsResult other = (BuildTargetTextDocumentsResult) obj;
+    if (this.textDocuments == null) {
+      if (other.textDocuments != null)
+        return false;
+    } else if (!this.textDocuments.equals(other.textDocuments))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.textDocuments== null) ? 0 : this.textDocuments.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CancelFileWatcherParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CancelFileWatcherParams.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class CancelFileWatcherParams {
+  @NonNull
+  private String id;
+  
+  public CancelFileWatcherParams(@NonNull final String id) {
+    this.id = id;
+  }
+  
+  @Pure
+  @NonNull
+  public String getId() {
+    return this.id;
+  }
+  
+  public void setId(@NonNull final String id) {
+    this.id = id;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("id", this.id);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CancelFileWatcherParams other = (CancelFileWatcherParams) obj;
+    if (this.id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!this.id.equals(other.id))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.id== null) ? 0 : this.id.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CancelFileWatcherResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CancelFileWatcherResult.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class CancelFileWatcherResult {
+  @NonNull
+  private Boolean cancelled;
+  
+  public CancelFileWatcherResult(@NonNull final Boolean cancelled) {
+    this.cancelled = cancelled;
+  }
+  
+  @Pure
+  @NonNull
+  public Boolean getCancelled() {
+    return this.cancelled;
+  }
+  
+  public void setCancelled(@NonNull final Boolean cancelled) {
+    this.cancelled = cancelled;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("cancelled", this.cancelled);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CancelFileWatcherResult other = (CancelFileWatcherResult) obj;
+    if (this.cancelled == null) {
+      if (other.cancelled != null)
+        return false;
+    } else if (!this.cancelled.equals(other.cancelled))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.cancelled== null) ? 0 : this.cancelled.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileParams.java
@@ -1,0 +1,100 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import com.google.gson.annotations.JsonAdapter;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class CompileParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  private String originId;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object arguments;
+  
+  public CompileParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  public Object getArguments() {
+    return this.arguments;
+  }
+  
+  public void setArguments(final Object arguments) {
+    this.arguments = arguments;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("originId", this.originId);
+    b.add("arguments", this.arguments);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CompileParams other = (CompileParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.arguments == null) {
+      if (other.arguments != null)
+        return false;
+    } else if (!this.arguments.equals(other.arguments))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.arguments== null) ? 0 : this.arguments.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileProvider.java
@@ -1,0 +1,51 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class CompileProvider {
+  private List<String> languageIds;
+  
+  @Pure
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+  
+  public void setLanguageIds(final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("languageIds", this.languageIds);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CompileProvider other = (CompileProvider) obj;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileReport.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileReport.java
@@ -1,0 +1,138 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class CompileReport {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  private String originId;
+  
+  @NonNull
+  private Integer errors;
+  
+  @NonNull
+  private Integer warnings;
+  
+  private Long time;
+  
+  public CompileReport(@NonNull final BuildTargetIdentifier target, final Integer errors, final Integer warnings) {
+    this.target = target;
+    this.errors = errors;
+    this.warnings = warnings;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = target;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getErrors() {
+    return this.errors;
+  }
+  
+  public void setErrors(@NonNull final Integer errors) {
+    this.errors = errors;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getWarnings() {
+    return this.warnings;
+  }
+  
+  public void setWarnings(@NonNull final Integer warnings) {
+    this.warnings = warnings;
+  }
+  
+  @Pure
+  public Long getTime() {
+    return this.time;
+  }
+  
+  public void setTime(final Long time) {
+    this.time = time;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("originId", this.originId);
+    b.add("errors", this.errors);
+    b.add("warnings", this.warnings);
+    b.add("time", this.time);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CompileReport other = (CompileReport) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.errors == null) {
+      if (other.errors != null)
+        return false;
+    } else if (!this.errors.equals(other.errors))
+      return false;
+    if (this.warnings == null) {
+      if (other.warnings != null)
+        return false;
+    } else if (!this.warnings.equals(other.warnings))
+      return false;
+    if (this.time == null) {
+      if (other.time != null)
+        return false;
+    } else if (!this.time.equals(other.time))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    result = prime * result + ((this.errors== null) ? 0 : this.errors.hashCode());
+    result = prime * result + ((this.warnings== null) ? 0 : this.warnings.hashCode());
+    return prime * result + ((this.time== null) ? 0 : this.time.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileResult.java
@@ -1,0 +1,73 @@
+package ch.epfl.scala.bsp4j;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class CompileResult {
+  private String originId;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("originId", this.originId);
+    b.add("data", this.data);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CompileResult other = (CompileResult) obj;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesItem.java
@@ -1,0 +1,82 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencySourcesItem {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  @NonNull
+  private List<String> sources;
+  
+  public DependencySourcesItem(@NonNull final List<BuildTargetIdentifier> targets, @NonNull final List<String> sources) {
+    this.targets = targets;
+    this.sources = sources;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getSources() {
+    return this.sources;
+  }
+  
+  public void setSources(@NonNull final List<String> sources) {
+    this.sources = sources;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("sources", this.sources);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencySourcesItem other = (DependencySourcesItem) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.sources == null) {
+      if (other.sources != null)
+        return false;
+    } else if (!this.sources.equals(other.sources))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    return prime * result + ((this.sources== null) ? 0 : this.sources.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencySourcesParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public DependencySourcesParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencySourcesParams other = (DependencySourcesParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DependencySourcesResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.DependencySourcesItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DependencySourcesResult {
+  @NonNull
+  private List<DependencySourcesItem> items;
+  
+  public DependencySourcesResult(@NonNull final List<DependencySourcesItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<DependencySourcesItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<DependencySourcesItem> items) {
+    this.items = items;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DependencySourcesResult other = (DependencySourcesResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Diagnostic.java
@@ -1,0 +1,155 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.DiagnosticRelatedInformation;
+import ch.epfl.scala.bsp4j.DiagnosticSeverity;
+import ch.epfl.scala.bsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class Diagnostic {
+  @NonNull
+  private Range range;
+  
+  private DiagnosticSeverity severity;
+  
+  private String code;
+  
+  private String source;
+  
+  @NonNull
+  private String message;
+  
+  private DiagnosticRelatedInformation relatedInformation;
+  
+  public Diagnostic(@NonNull final Range range, @NonNull final String message) {
+    this.range = range;
+    this.message = message;
+  }
+  
+  @Pure
+  @NonNull
+  public Range getRange() {
+    return this.range;
+  }
+  
+  public void setRange(@NonNull final Range range) {
+    this.range = range;
+  }
+  
+  @Pure
+  public DiagnosticSeverity getSeverity() {
+    return this.severity;
+  }
+  
+  public void setSeverity(final DiagnosticSeverity severity) {
+    this.severity = severity;
+  }
+  
+  @Pure
+  public String getCode() {
+    return this.code;
+  }
+  
+  public void setCode(final String code) {
+    this.code = code;
+  }
+  
+  @Pure
+  public String getSource() {
+    return this.source;
+  }
+  
+  public void setSource(final String source) {
+    this.source = source;
+  }
+  
+  @Pure
+  @NonNull
+  public String getMessage() {
+    return this.message;
+  }
+  
+  public void setMessage(@NonNull final String message) {
+    this.message = message;
+  }
+  
+  @Pure
+  public DiagnosticRelatedInformation getRelatedInformation() {
+    return this.relatedInformation;
+  }
+  
+  public void setRelatedInformation(final DiagnosticRelatedInformation relatedInformation) {
+    this.relatedInformation = relatedInformation;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("range", this.range);
+    b.add("severity", this.severity);
+    b.add("code", this.code);
+    b.add("source", this.source);
+    b.add("message", this.message);
+    b.add("relatedInformation", this.relatedInformation);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Diagnostic other = (Diagnostic) obj;
+    if (this.range == null) {
+      if (other.range != null)
+        return false;
+    } else if (!this.range.equals(other.range))
+      return false;
+    if (this.severity == null) {
+      if (other.severity != null)
+        return false;
+    } else if (!this.severity.equals(other.severity))
+      return false;
+    if (this.code == null) {
+      if (other.code != null)
+        return false;
+    } else if (!this.code.equals(other.code))
+      return false;
+    if (this.source == null) {
+      if (other.source != null)
+        return false;
+    } else if (!this.source.equals(other.source))
+      return false;
+    if (this.message == null) {
+      if (other.message != null)
+        return false;
+    } else if (!this.message.equals(other.message))
+      return false;
+    if (this.relatedInformation == null) {
+      if (other.relatedInformation != null)
+        return false;
+    } else if (!this.relatedInformation.equals(other.relatedInformation))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
+    result = prime * result + ((this.severity== null) ? 0 : this.severity.hashCode());
+    result = prime * result + ((this.code== null) ? 0 : this.code.hashCode());
+    result = prime * result + ((this.source== null) ? 0 : this.source.hashCode());
+    result = prime * result + ((this.message== null) ? 0 : this.message.hashCode());
+    return prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DiagnosticRelatedInformation.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DiagnosticRelatedInformation.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.Location;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DiagnosticRelatedInformation {
+  @NonNull
+  private Location location;
+  
+  @NonNull
+  private String message;
+  
+  public DiagnosticRelatedInformation(@NonNull final Location location, @NonNull final String message) {
+    this.location = location;
+    this.message = message;
+  }
+  
+  @Pure
+  @NonNull
+  public Location getLocation() {
+    return this.location;
+  }
+  
+  public void setLocation(@NonNull final Location location) {
+    this.location = location;
+  }
+  
+  @Pure
+  @NonNull
+  public String getMessage() {
+    return this.message;
+  }
+  
+  public void setMessage(@NonNull final String message) {
+    this.message = message;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("location", this.location);
+    b.add("message", this.message);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DiagnosticRelatedInformation other = (DiagnosticRelatedInformation) obj;
+    if (this.location == null) {
+      if (other.location != null)
+        return false;
+    } else if (!this.location.equals(other.location))
+      return false;
+    if (this.message == null) {
+      if (other.message != null)
+        return false;
+    } else if (!this.message.equals(other.message))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.location== null) ? 0 : this.location.hashCode());
+    return prime * result + ((this.message== null) ? 0 : this.message.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DidChangeBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DidChangeBuildTarget.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetEvent;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DidChangeBuildTarget {
+  @NonNull
+  private List<BuildTargetEvent> changes;
+  
+  public DidChangeBuildTarget(@NonNull final List<BuildTargetEvent> changes) {
+    this.changes = changes;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetEvent> getChanges() {
+    return this.changes;
+  }
+  
+  public void setChanges(@NonNull final List<BuildTargetEvent> changes) {
+    this.changes = changes;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("changes", this.changes);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DidChangeBuildTarget other = (DidChangeBuildTarget) obj;
+    if (this.changes == null) {
+      if (other.changes != null)
+        return false;
+    } else if (!this.changes.equals(other.changes))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.changes== null) ? 0 : this.changes.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DidChangeWatchedFiles.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DidChangeWatchedFiles.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.FileEvent;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DidChangeWatchedFiles {
+  private List<FileEvent> changes;
+  
+  public DidChangeWatchedFiles(@NonNull final List<FileEvent> changes) {
+    this.changes = changes;
+  }
+  
+  @Pure
+  public List<FileEvent> getChanges() {
+    return this.changes;
+  }
+  
+  public void setChanges(final List<FileEvent> changes) {
+    this.changes = changes;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("changes", this.changes);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DidChangeWatchedFiles other = (DidChangeWatchedFiles) obj;
+    if (this.changes == null) {
+      if (other.changes != null)
+        return false;
+    } else if (!this.changes.equals(other.changes))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.changes== null) ? 0 : this.changes.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FileEvent.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/FileEvent.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.FileChangeType;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class FileEvent {
+  @NonNull
+  private String uri;
+  
+  @NonNull
+  private FileChangeType type;
+  
+  public FileEvent(@NonNull final String uri, @NonNull final FileChangeType type) {
+    this.uri = uri;
+    this.type = type;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public FileChangeType getType() {
+    return this.type;
+  }
+  
+  public void setType(@NonNull final FileChangeType type) {
+    this.type = type;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    b.add("type", this.type);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FileEvent other = (FileEvent) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.type == null) {
+      if (other.type != null)
+        return false;
+    } else if (!this.type.equals(other.type))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    return prime * result + ((this.type== null) ? 0 : this.type.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildParams.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildClientCapabilities;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class InitializeBuildParams {
+  @NonNull
+  private String rootUri;
+  
+  @NonNull
+  private BuildClientCapabilities capabilities;
+  
+  public InitializeBuildParams(@NonNull final String rootUri, @NonNull final BuildClientCapabilities capabilities) {
+    this.rootUri = rootUri;
+    this.capabilities = capabilities;
+  }
+  
+  @Pure
+  @NonNull
+  public String getRootUri() {
+    return this.rootUri;
+  }
+  
+  public void setRootUri(@NonNull final String rootUri) {
+    this.rootUri = rootUri;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildClientCapabilities getCapabilities() {
+    return this.capabilities;
+  }
+  
+  public void setCapabilities(@NonNull final BuildClientCapabilities capabilities) {
+    this.capabilities = capabilities;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("rootUri", this.rootUri);
+    b.add("capabilities", this.capabilities);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    InitializeBuildParams other = (InitializeBuildParams) obj;
+    if (this.rootUri == null) {
+      if (other.rootUri != null)
+        return false;
+    } else if (!this.rootUri.equals(other.rootUri))
+      return false;
+    if (this.capabilities == null) {
+      if (other.capabilities != null)
+        return false;
+    } else if (!this.capabilities.equals(other.capabilities))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.rootUri== null) ? 0 : this.rootUri.hashCode());
+    return prime * result + ((this.capabilities== null) ? 0 : this.capabilities.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InitializeBuildResult.java
@@ -1,0 +1,58 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildServerCapabilities;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class InitializeBuildResult {
+  @NonNull
+  private BuildServerCapabilities capabilities;
+  
+  public InitializeBuildResult(@NonNull final BuildServerCapabilities capabilities) {
+    this.capabilities = capabilities;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildServerCapabilities getCapabilities() {
+    return this.capabilities;
+  }
+  
+  public void setCapabilities(@NonNull final BuildServerCapabilities capabilities) {
+    this.capabilities = capabilities;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("capabilities", this.capabilities);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    InitializeBuildResult other = (InitializeBuildResult) obj;
+    if (this.capabilities == null) {
+      if (other.capabilities != null)
+        return false;
+    } else if (!this.capabilities.equals(other.capabilities))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.capabilities== null) ? 0 : this.capabilities.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Location.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Location.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class Location {
+  @NonNull
+  private String uri;
+  
+  @NonNull
+  private Range range;
+  
+  public Location(@NonNull final String uri, @NonNull final Range range) {
+    this.uri = uri;
+    this.range = range;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public Range getRange() {
+    return this.range;
+  }
+  
+  public void setRange(@NonNull final Range range) {
+    this.range = range;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    b.add("range", this.range);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Location other = (Location) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.range == null) {
+      if (other.range != null)
+        return false;
+    } else if (!this.range.equals(other.range))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    return prime * result + ((this.range== null) ? 0 : this.range.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/LogMessageParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/LogMessageParams.java
@@ -1,0 +1,118 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.MessageType;
+import ch.epfl.scala.bsp4j.TaskId;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class LogMessageParams {
+  @NonNull
+  private MessageType type;
+  
+  private TaskId task;
+  
+  private String originId;
+  
+  @NonNull
+  private String message;
+  
+  public LogMessageParams(@NonNull final MessageType type, @NonNull final String message) {
+    this.type = type;
+    this.message = message;
+  }
+  
+  @Pure
+  @NonNull
+  public MessageType getType() {
+    return this.type;
+  }
+  
+  public void setType(@NonNull final MessageType type) {
+    this.type = type;
+  }
+  
+  @Pure
+  public TaskId getTask() {
+    return this.task;
+  }
+  
+  public void setTask(final TaskId task) {
+    this.task = task;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  @NonNull
+  public String getMessage() {
+    return this.message;
+  }
+  
+  public void setMessage(@NonNull final String message) {
+    this.message = message;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("type", this.type);
+    b.add("task", this.task);
+    b.add("originId", this.originId);
+    b.add("message", this.message);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    LogMessageParams other = (LogMessageParams) obj;
+    if (this.type == null) {
+      if (other.type != null)
+        return false;
+    } else if (!this.type.equals(other.type))
+      return false;
+    if (this.task == null) {
+      if (other.task != null)
+        return false;
+    } else if (!this.task.equals(other.task))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.message == null) {
+      if (other.message != null)
+        return false;
+    } else if (!this.message.equals(other.message))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.type== null) ? 0 : this.type.hashCode());
+    result = prime * result + ((this.task== null) ? 0 : this.task.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.message== null) ? 0 : this.message.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Position.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Position.java
@@ -1,0 +1,80 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class Position {
+  @NonNull
+  private Integer line;
+  
+  @NonNull
+  private Integer character;
+  
+  public Position(@NonNull final Integer line, @NonNull final Integer character) {
+    this.line = line;
+    this.character = character;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getLine() {
+    return this.line;
+  }
+  
+  public void setLine(@NonNull final Integer line) {
+    this.line = line;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getCharacter() {
+    return this.character;
+  }
+  
+  public void setCharacter(@NonNull final Integer character) {
+    this.character = character;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("line", this.line);
+    b.add("character", this.character);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Position other = (Position) obj;
+    if (this.line == null) {
+      if (other.line != null)
+        return false;
+    } else if (!this.line.equals(other.line))
+      return false;
+    if (this.character == null) {
+      if (other.character != null)
+        return false;
+    } else if (!this.character.equals(other.character))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.line== null) ? 0 : this.line.hashCode());
+    return prime * result + ((this.character== null) ? 0 : this.character.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
@@ -1,0 +1,97 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.Diagnostic;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class PublishDiagnosticsParams {
+  @NonNull
+  private String uri;
+  
+  private String originId;
+  
+  private List<Diagnostic> diagnostics;
+  
+  public PublishDiagnosticsParams(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  public List<Diagnostic> getDiagnostics() {
+    return this.diagnostics;
+  }
+  
+  public void setDiagnostics(final List<Diagnostic> diagnostics) {
+    this.diagnostics = diagnostics;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    b.add("originId", this.originId);
+    b.add("diagnostics", this.diagnostics);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    PublishDiagnosticsParams other = (PublishDiagnosticsParams) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.diagnostics == null) {
+      if (other.diagnostics != null)
+        return false;
+    } else if (!this.diagnostics.equals(other.diagnostics))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Range.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/Range.java
@@ -1,0 +1,81 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class Range {
+  @NonNull
+  private Position start;
+  
+  @NonNull
+  private Position end;
+  
+  public Range(@NonNull final Position start, @NonNull final Position end) {
+    this.start = start;
+    this.end = end;
+  }
+  
+  @Pure
+  @NonNull
+  public Position getStart() {
+    return this.start;
+  }
+  
+  public void setStart(@NonNull final Position start) {
+    this.start = start;
+  }
+  
+  @Pure
+  @NonNull
+  public Position getEnd() {
+    return this.end;
+  }
+  
+  public void setEnd(@NonNull final Position end) {
+    this.end = end;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("start", this.start);
+    b.add("end", this.end);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Range other = (Range) obj;
+    if (this.start == null) {
+      if (other.start != null)
+        return false;
+    } else if (!this.start.equals(other.start))
+      return false;
+    if (this.end == null) {
+      if (other.end != null)
+        return false;
+    } else if (!this.end.equals(other.end))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.start== null) ? 0 : this.start.hashCode());
+    return prime * result + ((this.end== null) ? 0 : this.end.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RegisterFileWatcherParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RegisterFileWatcherParams.java
@@ -1,0 +1,78 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.WatchKind;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class RegisterFileWatcherParams {
+  @NonNull
+  private String globPattern;
+  
+  private WatchKind kind;
+  
+  public RegisterFileWatcherParams(@NonNull final String globPattern) {
+    this.globPattern = globPattern;
+  }
+  
+  @Pure
+  @NonNull
+  public String getGlobPattern() {
+    return this.globPattern;
+  }
+  
+  public void setGlobPattern(@NonNull final String globPattern) {
+    this.globPattern = globPattern;
+  }
+  
+  @Pure
+  public WatchKind getKind() {
+    return this.kind;
+  }
+  
+  public void setKind(final WatchKind kind) {
+    this.kind = kind;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("globPattern", this.globPattern);
+    b.add("kind", this.kind);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    RegisterFileWatcherParams other = (RegisterFileWatcherParams) obj;
+    if (this.globPattern == null) {
+      if (other.globPattern != null)
+        return false;
+    } else if (!this.globPattern.equals(other.globPattern))
+      return false;
+    if (this.kind == null) {
+      if (other.kind != null)
+        return false;
+    } else if (!this.kind.equals(other.kind))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.globPattern== null) ? 0 : this.globPattern.hashCode());
+    return prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RegisterFileWatcherResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RegisterFileWatcherResult.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class RegisterFileWatcherResult {
+  @NonNull
+  private String id;
+  
+  public RegisterFileWatcherResult(@NonNull final String id) {
+    this.id = id;
+  }
+  
+  @Pure
+  @NonNull
+  public String getId() {
+    return this.id;
+  }
+  
+  public void setId(@NonNull final String id) {
+    this.id = id;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("id", this.id);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    RegisterFileWatcherResult other = (RegisterFileWatcherResult) obj;
+    if (this.id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!this.id.equals(other.id))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.id== null) ? 0 : this.id.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesItem.java
@@ -1,0 +1,82 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ResourcesItem {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  @NonNull
+  private List<String> resources;
+  
+  public ResourcesItem(@NonNull final List<BuildTargetIdentifier> targets, @NonNull final List<String> resources) {
+    this.targets = targets;
+    this.resources = resources;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getResources() {
+    return this.resources;
+  }
+  
+  public void setResources(@NonNull final List<String> resources) {
+    this.resources = resources;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("resources", this.resources);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ResourcesItem other = (ResourcesItem) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.resources == null) {
+      if (other.resources != null)
+        return false;
+    } else if (!this.resources.equals(other.resources))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    return prime * result + ((this.resources== null) ? 0 : this.resources.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ResourcesParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public ResourcesParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ResourcesParams other = (ResourcesParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ResourcesResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.ResourcesItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ResourcesResult {
+  @NonNull
+  private List<ResourcesItem> items;
+  
+  public ResourcesResult(@NonNull final List<ResourcesItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<ResourcesItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<ResourcesItem> items) {
+    this.items = items;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ResourcesResult other = (ResourcesResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunParams.java
@@ -1,0 +1,100 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import com.google.gson.annotations.JsonAdapter;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class RunParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  private String originId;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object arguments;
+  
+  public RunParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  public Object getArguments() {
+    return this.arguments;
+  }
+  
+  public void setArguments(final Object arguments) {
+    this.arguments = arguments;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("originId", this.originId);
+    b.add("arguments", this.arguments);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    RunParams other = (RunParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.arguments == null) {
+      if (other.arguments != null)
+        return false;
+    } else if (!this.arguments.equals(other.arguments))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.arguments== null) ? 0 : this.arguments.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunProvider.java
@@ -1,0 +1,51 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class RunProvider {
+  private List<String> languageIds;
+  
+  @Pure
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+  
+  public void setLanguageIds(final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("languageIds", this.languageIds);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    RunProvider other = (RunProvider) obj;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/RunResult.java
@@ -1,0 +1,78 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.StatusCode;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class RunResult {
+  private String originId;
+  
+  @NonNull
+  private StatusCode statusCode;
+  
+  public RunResult(@NonNull final StatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  @NonNull
+  public StatusCode getStatusCode() {
+    return this.statusCode;
+  }
+  
+  public void setStatusCode(@NonNull final StatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("originId", this.originId);
+    b.add("statusCode", this.statusCode);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    RunResult other = (RunResult) obj;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.statusCode == null) {
+      if (other.statusCode != null)
+        return false;
+    } else if (!this.statusCode.equals(other.statusCode))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.statusCode== null) ? 0 : this.statusCode.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SbtBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/SbtBuildTarget.java
@@ -1,0 +1,164 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.ScalaBuildTarget;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class SbtBuildTarget {
+  @NonNull
+  private String sbtVersion;
+  
+  @NonNull
+  private List<String> autoImports;
+  
+  @NonNull
+  private List<String> classpath;
+  
+  @NonNull
+  private ScalaBuildTarget scalaBuildTarget;
+  
+  private BuildTargetIdentifier parent;
+  
+  @NonNull
+  private List<BuildTargetIdentifier> children;
+  
+  public SbtBuildTarget(@NonNull final String sbtVersion, @NonNull final List<String> autoImports, @NonNull final List<String> classpath, @NonNull final ScalaBuildTarget scalaBuildTarget, @NonNull final List<BuildTargetIdentifier> children) {
+    this.sbtVersion = sbtVersion;
+    this.autoImports = autoImports;
+    this.classpath = classpath;
+    this.scalaBuildTarget = scalaBuildTarget;
+    this.children = children;
+  }
+  
+  @Pure
+  @NonNull
+  public String getSbtVersion() {
+    return this.sbtVersion;
+  }
+  
+  public void setSbtVersion(@NonNull final String sbtVersion) {
+    this.sbtVersion = sbtVersion;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getAutoImports() {
+    return this.autoImports;
+  }
+  
+  public void setAutoImports(@NonNull final List<String> autoImports) {
+    this.autoImports = autoImports;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getClasspath() {
+    return this.classpath;
+  }
+  
+  public void setClasspath(@NonNull final List<String> classpath) {
+    this.classpath = classpath;
+  }
+  
+  @Pure
+  @NonNull
+  public ScalaBuildTarget getScalaBuildTarget() {
+    return this.scalaBuildTarget;
+  }
+  
+  public void setScalaBuildTarget(@NonNull final ScalaBuildTarget scalaBuildTarget) {
+    this.scalaBuildTarget = scalaBuildTarget;
+  }
+  
+  @Pure
+  public BuildTargetIdentifier getParent() {
+    return this.parent;
+  }
+  
+  public void setParent(final BuildTargetIdentifier parent) {
+    this.parent = parent;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getChildren() {
+    return this.children;
+  }
+  
+  public void setChildren(@NonNull final List<BuildTargetIdentifier> children) {
+    this.children = children;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("sbtVersion", this.sbtVersion);
+    b.add("autoImports", this.autoImports);
+    b.add("classpath", this.classpath);
+    b.add("scalaBuildTarget", this.scalaBuildTarget);
+    b.add("parent", this.parent);
+    b.add("children", this.children);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SbtBuildTarget other = (SbtBuildTarget) obj;
+    if (this.sbtVersion == null) {
+      if (other.sbtVersion != null)
+        return false;
+    } else if (!this.sbtVersion.equals(other.sbtVersion))
+      return false;
+    if (this.autoImports == null) {
+      if (other.autoImports != null)
+        return false;
+    } else if (!this.autoImports.equals(other.autoImports))
+      return false;
+    if (this.classpath == null) {
+      if (other.classpath != null)
+        return false;
+    } else if (!this.classpath.equals(other.classpath))
+      return false;
+    if (this.scalaBuildTarget == null) {
+      if (other.scalaBuildTarget != null)
+        return false;
+    } else if (!this.scalaBuildTarget.equals(other.scalaBuildTarget))
+      return false;
+    if (this.parent == null) {
+      if (other.parent != null)
+        return false;
+    } else if (!this.parent.equals(other.parent))
+      return false;
+    if (this.children == null) {
+      if (other.children != null)
+        return false;
+    } else if (!this.children.equals(other.children))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.sbtVersion== null) ? 0 : this.sbtVersion.hashCode());
+    result = prime * result + ((this.autoImports== null) ? 0 : this.autoImports.hashCode());
+    result = prime * result + ((this.classpath== null) ? 0 : this.classpath.hashCode());
+    result = prime * result + ((this.scalaBuildTarget== null) ? 0 : this.scalaBuildTarget.hashCode());
+    result = prime * result + ((this.parent== null) ? 0 : this.parent.hashCode());
+    return prime * result + ((this.children== null) ? 0 : this.children.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaBuildTarget.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaBuildTarget.java
@@ -1,0 +1,145 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.ScalaPlatform;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaBuildTarget {
+  @NonNull
+  private String scalaOrganization;
+  
+  @NonNull
+  private String scalaVersion;
+  
+  @NonNull
+  private String scalaBinaryVersion;
+  
+  @NonNull
+  private ScalaPlatform platform;
+  
+  @NonNull
+  private List<String> jars;
+  
+  public ScalaBuildTarget(@NonNull final String scalaOrganization, @NonNull final String scalaVersion, @NonNull final String scalaBinaryVersion, @NonNull final ScalaPlatform platform, @NonNull final List<String> jars) {
+    this.scalaOrganization = scalaOrganization;
+    this.scalaVersion = scalaVersion;
+    this.scalaBinaryVersion = scalaBinaryVersion;
+    this.platform = platform;
+    this.jars = jars;
+  }
+  
+  @Pure
+  @NonNull
+  public String getScalaOrganization() {
+    return this.scalaOrganization;
+  }
+  
+  public void setScalaOrganization(@NonNull final String scalaOrganization) {
+    this.scalaOrganization = scalaOrganization;
+  }
+  
+  @Pure
+  @NonNull
+  public String getScalaVersion() {
+    return this.scalaVersion;
+  }
+  
+  public void setScalaVersion(@NonNull final String scalaVersion) {
+    this.scalaVersion = scalaVersion;
+  }
+  
+  @Pure
+  @NonNull
+  public String getScalaBinaryVersion() {
+    return this.scalaBinaryVersion;
+  }
+  
+  public void setScalaBinaryVersion(@NonNull final String scalaBinaryVersion) {
+    this.scalaBinaryVersion = scalaBinaryVersion;
+  }
+  
+  @Pure
+  @NonNull
+  public ScalaPlatform getPlatform() {
+    return this.platform;
+  }
+  
+  public void setPlatform(@NonNull final ScalaPlatform platform) {
+    this.platform = platform;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getJars() {
+    return this.jars;
+  }
+  
+  public void setJars(@NonNull final List<String> jars) {
+    this.jars = jars;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("scalaOrganization", this.scalaOrganization);
+    b.add("scalaVersion", this.scalaVersion);
+    b.add("scalaBinaryVersion", this.scalaBinaryVersion);
+    b.add("platform", this.platform);
+    b.add("jars", this.jars);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaBuildTarget other = (ScalaBuildTarget) obj;
+    if (this.scalaOrganization == null) {
+      if (other.scalaOrganization != null)
+        return false;
+    } else if (!this.scalaOrganization.equals(other.scalaOrganization))
+      return false;
+    if (this.scalaVersion == null) {
+      if (other.scalaVersion != null)
+        return false;
+    } else if (!this.scalaVersion.equals(other.scalaVersion))
+      return false;
+    if (this.scalaBinaryVersion == null) {
+      if (other.scalaBinaryVersion != null)
+        return false;
+    } else if (!this.scalaBinaryVersion.equals(other.scalaBinaryVersion))
+      return false;
+    if (this.platform == null) {
+      if (other.platform != null)
+        return false;
+    } else if (!this.platform.equals(other.platform))
+      return false;
+    if (this.jars == null) {
+      if (other.jars != null)
+        return false;
+    } else if (!this.jars.equals(other.jars))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.scalaOrganization== null) ? 0 : this.scalaOrganization.hashCode());
+    result = prime * result + ((this.scalaVersion== null) ? 0 : this.scalaVersion.hashCode());
+    result = prime * result + ((this.scalaBinaryVersion== null) ? 0 : this.scalaBinaryVersion.hashCode());
+    result = prime * result + ((this.platform== null) ? 0 : this.platform.hashCode());
+    return prime * result + ((this.jars== null) ? 0 : this.jars.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClass.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClass.java
@@ -1,0 +1,98 @@
+package ch.epfl.scala.bsp4j;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaMainClass {
+  @NonNull
+  @SerializedName("class")
+  private String className;
+  
+  @NonNull
+  private List<String> arguments;
+  
+  @NonNull
+  private List<String> jvmOptions;
+  
+  @Pure
+  @NonNull
+  public String getClassName() {
+    return this.className;
+  }
+  
+  public void setClassName(@NonNull final String className) {
+    this.className = className;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getArguments() {
+    return this.arguments;
+  }
+  
+  public void setArguments(@NonNull final List<String> arguments) {
+    this.arguments = arguments;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getJvmOptions() {
+    return this.jvmOptions;
+  }
+  
+  public void setJvmOptions(@NonNull final List<String> jvmOptions) {
+    this.jvmOptions = jvmOptions;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("className", this.className);
+    b.add("arguments", this.arguments);
+    b.add("jvmOptions", this.jvmOptions);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaMainClass other = (ScalaMainClass) obj;
+    if (this.className == null) {
+      if (other.className != null)
+        return false;
+    } else if (!this.className.equals(other.className))
+      return false;
+    if (this.arguments == null) {
+      if (other.arguments != null)
+        return false;
+    } else if (!this.arguments.equals(other.arguments))
+      return false;
+    if (this.jvmOptions == null) {
+      if (other.jvmOptions != null)
+        return false;
+    } else if (!this.jvmOptions.equals(other.jvmOptions))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.className== null) ? 0 : this.className.hashCode());
+    result = prime * result + ((this.arguments== null) ? 0 : this.arguments.hashCode());
+    return prime * result + ((this.jvmOptions== null) ? 0 : this.jvmOptions.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesItem.java
@@ -1,0 +1,83 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import ch.epfl.scala.bsp4j.ScalaMainClass;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaMainClassesItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  @NonNull
+  private List<ScalaMainClass> classes;
+  
+  public ScalaMainClassesItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<ScalaMainClass> classes) {
+    this.target = target;
+    this.classes = classes;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = target;
+  }
+  
+  @Pure
+  @NonNull
+  public List<ScalaMainClass> getClasses() {
+    return this.classes;
+  }
+  
+  public void setClasses(@NonNull final List<ScalaMainClass> classes) {
+    this.classes = classes;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("classes", this.classes);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaMainClassesItem other = (ScalaMainClassesItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.classes == null) {
+      if (other.classes != null)
+        return false;
+    } else if (!this.classes.equals(other.classes))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    return prime * result + ((this.classes== null) ? 0 : this.classes.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesParams.java
@@ -1,0 +1,79 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaMainClassesParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  private String originId;
+  
+  public ScalaMainClassesParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("originId", this.originId);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaMainClassesParams other = (ScalaMainClassesParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    return prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaMainClassesResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.ScalaMainClassesItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaMainClassesResult {
+  @NonNull
+  private List<ScalaMainClassesItem> items;
+  
+  public ScalaMainClassesResult(@NonNull final List<ScalaMainClassesItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<ScalaMainClassesItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<ScalaMainClassesItem> items) {
+    this.items = items;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaMainClassesResult other = (ScalaMainClassesResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesItem.java
@@ -1,0 +1,82 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaTestClassesItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  @NonNull
+  private List<String> classes;
+  
+  public ScalaTestClassesItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<String> classes) {
+    this.target = target;
+    this.classes = classes;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = target;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getClasses() {
+    return this.classes;
+  }
+  
+  public void setClasses(@NonNull final List<String> classes) {
+    this.classes = classes;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("classes", this.classes);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaTestClassesItem other = (ScalaTestClassesItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.classes == null) {
+      if (other.classes != null)
+        return false;
+    } else if (!this.classes.equals(other.classes))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    return prime * result + ((this.classes== null) ? 0 : this.classes.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesParams.java
@@ -1,0 +1,79 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaTestClassesParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  private String originId;
+  
+  public ScalaTestClassesParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("originId", this.originId);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaTestClassesParams other = (ScalaTestClassesParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    return prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalaTestClassesResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.ScalaTestClassesItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalaTestClassesResult {
+  @NonNull
+  private List<ScalaTestClassesItem> items;
+  
+  public ScalaTestClassesResult(@NonNull final List<ScalaTestClassesItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<ScalaTestClassesItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<ScalaTestClassesItem> items) {
+    this.items = items;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalaTestClassesResult other = (ScalaTestClassesResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsItem.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsItem.java
@@ -1,0 +1,124 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalacOptionsItem {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  @NonNull
+  private List<String> options;
+  
+  @NonNull
+  private List<String> classpath;
+  
+  @NonNull
+  private String classDirectory;
+  
+  public ScalacOptionsItem(@NonNull final BuildTargetIdentifier target, @NonNull final List<String> options, @NonNull final List<String> classpath, @NonNull final String classDirectory) {
+    this.target = target;
+    this.options = options;
+    this.classpath = classpath;
+    this.classDirectory = classDirectory;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = target;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getOptions() {
+    return this.options;
+  }
+  
+  public void setOptions(@NonNull final List<String> options) {
+    this.options = options;
+  }
+  
+  @Pure
+  @NonNull
+  public List<String> getClasspath() {
+    return this.classpath;
+  }
+  
+  public void setClasspath(@NonNull final List<String> classpath) {
+    this.classpath = classpath;
+  }
+  
+  @Pure
+  @NonNull
+  public String getClassDirectory() {
+    return this.classDirectory;
+  }
+  
+  public void setClassDirectory(@NonNull final String classDirectory) {
+    this.classDirectory = classDirectory;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("options", this.options);
+    b.add("classpath", this.classpath);
+    b.add("classDirectory", this.classDirectory);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalacOptionsItem other = (ScalacOptionsItem) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.options == null) {
+      if (other.options != null)
+        return false;
+    } else if (!this.options.equals(other.options))
+      return false;
+    if (this.classpath == null) {
+      if (other.classpath != null)
+        return false;
+    } else if (!this.classpath.equals(other.classpath))
+      return false;
+    if (this.classDirectory == null) {
+      if (other.classDirectory != null)
+        return false;
+    } else if (!this.classDirectory.equals(other.classDirectory))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    result = prime * result + ((this.options== null) ? 0 : this.options.hashCode());
+    result = prime * result + ((this.classpath== null) ? 0 : this.classpath.hashCode());
+    return prime * result + ((this.classDirectory== null) ? 0 : this.classDirectory.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalacOptionsParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public ScalacOptionsParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalacOptionsParams other = (ScalacOptionsParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ScalacOptionsResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.ScalacOptionsItem;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ScalacOptionsResult {
+  @NonNull
+  private List<ScalacOptionsItem> items;
+  
+  public ScalacOptionsResult(@NonNull final List<ScalacOptionsItem> items) {
+    this.items = items;
+  }
+  
+  @Pure
+  @NonNull
+  public List<ScalacOptionsItem> getItems() {
+    return this.items;
+  }
+  
+  public void setItems(@NonNull final List<ScalacOptionsItem> items) {
+    this.items = items;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("items", this.items);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ScalacOptionsResult other = (ScalacOptionsResult) obj;
+    if (this.items == null) {
+      if (other.items != null)
+        return false;
+    } else if (!this.items.equals(other.items))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.items== null) ? 0 : this.items.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ShowMessageParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/ShowMessageParams.java
@@ -1,0 +1,118 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.MessageType;
+import ch.epfl.scala.bsp4j.TaskId;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ShowMessageParams {
+  @NonNull
+  private MessageType type;
+  
+  private TaskId task;
+  
+  private String originId;
+  
+  @NonNull
+  private String message;
+  
+  public ShowMessageParams(@NonNull final MessageType type, @NonNull final String message) {
+    this.type = type;
+    this.message = message;
+  }
+  
+  @Pure
+  @NonNull
+  public MessageType getType() {
+    return this.type;
+  }
+  
+  public void setType(@NonNull final MessageType type) {
+    this.type = type;
+  }
+  
+  @Pure
+  public TaskId getTask() {
+    return this.task;
+  }
+  
+  public void setTask(final TaskId task) {
+    this.task = task;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  @NonNull
+  public String getMessage() {
+    return this.message;
+  }
+  
+  public void setMessage(@NonNull final String message) {
+    this.message = message;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("type", this.type);
+    b.add("task", this.task);
+    b.add("originId", this.originId);
+    b.add("message", this.message);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ShowMessageParams other = (ShowMessageParams) obj;
+    if (this.type == null) {
+      if (other.type != null)
+        return false;
+    } else if (!this.type.equals(other.type))
+      return false;
+    if (this.task == null) {
+      if (other.task != null)
+        return false;
+    } else if (!this.task.equals(other.task))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.message == null) {
+      if (other.message != null)
+        return false;
+    } else if (!this.message.equals(other.message))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.type== null) ? 0 : this.type.hashCode());
+    result = prime * result + ((this.task== null) ? 0 : this.task.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.message== null) ? 0 : this.message.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskId.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskId.java
@@ -1,0 +1,77 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TaskId {
+  @NonNull
+  private String id;
+  
+  private String parent;
+  
+  public TaskId(@NonNull final String id) {
+    this.id = id;
+  }
+  
+  @Pure
+  @NonNull
+  public String getId() {
+    return this.id;
+  }
+  
+  public void setId(@NonNull final String id) {
+    this.id = id;
+  }
+  
+  @Pure
+  public String getParent() {
+    return this.parent;
+  }
+  
+  public void setParent(final String parent) {
+    this.parent = parent;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("id", this.id);
+    b.add("parent", this.parent);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TaskId other = (TaskId) obj;
+    if (this.id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!this.id.equals(other.id))
+      return false;
+    if (this.parent == null) {
+      if (other.parent != null)
+        return false;
+    } else if (!this.parent.equals(other.parent))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.id== null) ? 0 : this.id.hashCode());
+    return prime * result + ((this.parent== null) ? 0 : this.parent.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestParams.java
@@ -1,0 +1,100 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import com.google.gson.annotations.JsonAdapter;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TestParams {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  private String originId;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object arguments;
+  
+  public TestParams(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  public Object getArguments() {
+    return this.arguments;
+  }
+  
+  public void setArguments(final Object arguments) {
+    this.arguments = arguments;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    b.add("originId", this.originId);
+    b.add("arguments", this.arguments);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TestParams other = (TestParams) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.arguments == null) {
+      if (other.arguments != null)
+        return false;
+    } else if (!this.arguments.equals(other.arguments))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.targets== null) ? 0 : this.targets.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.arguments== null) ? 0 : this.arguments.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestProvider.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestProvider.java
@@ -1,0 +1,51 @@
+package ch.epfl.scala.bsp4j;
+
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TestProvider {
+  private List<String> languageIds;
+  
+  @Pure
+  public List<String> getLanguageIds() {
+    return this.languageIds;
+  }
+  
+  public void setLanguageIds(final List<String> languageIds) {
+    this.languageIds = languageIds;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("languageIds", this.languageIds);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TestProvider other = (TestProvider) obj;
+    if (this.languageIds == null) {
+      if (other.languageIds != null)
+        return false;
+    } else if (!this.languageIds.equals(other.languageIds))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.languageIds== null) ? 0 : this.languageIds.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestReport.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestReport.java
@@ -1,0 +1,201 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TestReport {
+  @NonNull
+  private BuildTargetIdentifier target;
+  
+  private String originId;
+  
+  @NonNull
+  private Integer passed;
+  
+  @NonNull
+  private Integer failed;
+  
+  @NonNull
+  private Integer ignored;
+  
+  @NonNull
+  private Integer cancelled;
+  
+  @NonNull
+  private Integer skipped;
+  
+  private Long time;
+  
+  public TestReport(@NonNull final BuildTargetIdentifier target, final Integer passed, final Integer failed, final Integer ignored, final Integer cancelled, final Integer skipped) {
+    this.target = target;
+    this.passed = passed;
+    this.failed = failed;
+    this.ignored = ignored;
+    this.cancelled = cancelled;
+    this.skipped = skipped;
+  }
+  
+  @Pure
+  @NonNull
+  public BuildTargetIdentifier getTarget() {
+    return this.target;
+  }
+  
+  public void setTarget(@NonNull final BuildTargetIdentifier target) {
+    this.target = target;
+  }
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getPassed() {
+    return this.passed;
+  }
+  
+  public void setPassed(@NonNull final Integer passed) {
+    this.passed = passed;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getFailed() {
+    return this.failed;
+  }
+  
+  public void setFailed(@NonNull final Integer failed) {
+    this.failed = failed;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getIgnored() {
+    return this.ignored;
+  }
+  
+  public void setIgnored(@NonNull final Integer ignored) {
+    this.ignored = ignored;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getCancelled() {
+    return this.cancelled;
+  }
+  
+  public void setCancelled(@NonNull final Integer cancelled) {
+    this.cancelled = cancelled;
+  }
+  
+  @Pure
+  @NonNull
+  public Integer getSkipped() {
+    return this.skipped;
+  }
+  
+  public void setSkipped(@NonNull final Integer skipped) {
+    this.skipped = skipped;
+  }
+  
+  @Pure
+  public Long getTime() {
+    return this.time;
+  }
+  
+  public void setTime(final Long time) {
+    this.time = time;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("target", this.target);
+    b.add("originId", this.originId);
+    b.add("passed", this.passed);
+    b.add("failed", this.failed);
+    b.add("ignored", this.ignored);
+    b.add("cancelled", this.cancelled);
+    b.add("skipped", this.skipped);
+    b.add("time", this.time);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TestReport other = (TestReport) obj;
+    if (this.target == null) {
+      if (other.target != null)
+        return false;
+    } else if (!this.target.equals(other.target))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.passed == null) {
+      if (other.passed != null)
+        return false;
+    } else if (!this.passed.equals(other.passed))
+      return false;
+    if (this.failed == null) {
+      if (other.failed != null)
+        return false;
+    } else if (!this.failed.equals(other.failed))
+      return false;
+    if (this.ignored == null) {
+      if (other.ignored != null)
+        return false;
+    } else if (!this.ignored.equals(other.ignored))
+      return false;
+    if (this.cancelled == null) {
+      if (other.cancelled != null)
+        return false;
+    } else if (!this.cancelled.equals(other.cancelled))
+      return false;
+    if (this.skipped == null) {
+      if (other.skipped != null)
+        return false;
+    } else if (!this.skipped.equals(other.skipped))
+      return false;
+    if (this.time == null) {
+      if (other.time != null)
+        return false;
+    } else if (!this.time.equals(other.time))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    result = prime * result + ((this.passed== null) ? 0 : this.passed.hashCode());
+    result = prime * result + ((this.failed== null) ? 0 : this.failed.hashCode());
+    result = prime * result + ((this.ignored== null) ? 0 : this.ignored.hashCode());
+    result = prime * result + ((this.cancelled== null) ? 0 : this.cancelled.hashCode());
+    result = prime * result + ((this.skipped== null) ? 0 : this.skipped.hashCode());
+    return prime * result + ((this.time== null) ? 0 : this.time.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestResult.java
@@ -1,0 +1,73 @@
+package ch.epfl.scala.bsp4j;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TestResult {
+  private String originId;
+  
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
+  
+  @Pure
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("originId", this.originId);
+    b.add("data", this.data);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TestResult other = (TestResult) obj;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentBuildTargetsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentBuildTargetsParams.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.TextDocumentIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TextDocumentBuildTargetsParams {
+  @NonNull
+  private List<TextDocumentIdentifier> textDocuments;
+  
+  public TextDocumentBuildTargetsParams(@NonNull final List<TextDocumentIdentifier> textDocuments) {
+    this.textDocuments = textDocuments;
+  }
+  
+  @Pure
+  @NonNull
+  public List<TextDocumentIdentifier> getTextDocuments() {
+    return this.textDocuments;
+  }
+  
+  public void setTextDocuments(@NonNull final List<TextDocumentIdentifier> textDocuments) {
+    this.textDocuments = textDocuments;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("textDocuments", this.textDocuments);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TextDocumentBuildTargetsParams other = (TextDocumentBuildTargetsParams) obj;
+    if (this.textDocuments == null) {
+      if (other.textDocuments != null)
+        return false;
+    } else if (!this.textDocuments.equals(other.textDocuments))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.textDocuments== null) ? 0 : this.textDocuments.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentBuildTargetsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentBuildTargetsResult.java
@@ -1,0 +1,59 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TextDocumentBuildTargetsResult {
+  @NonNull
+  private List<BuildTargetIdentifier> targets;
+  
+  public TextDocumentBuildTargetsResult(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  @NonNull
+  public List<BuildTargetIdentifier> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(@NonNull final List<BuildTargetIdentifier> targets) {
+    this.targets = targets;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TextDocumentBuildTargetsResult other = (TextDocumentBuildTargetsResult) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentIdentifier.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TextDocumentIdentifier.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class TextDocumentIdentifier {
+  @NonNull
+  private String uri;
+  
+  public TextDocumentIdentifier(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("uri", this.uri);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TextDocumentIdentifier other = (TextDocumentIdentifier) obj;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.uri== null) ? 0 : this.uri.hashCode());
+  }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/WorkspaceBuildTargetsResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/WorkspaceBuildTargetsResult.java
@@ -1,0 +1,57 @@
+package ch.epfl.scala.bsp4j;
+
+import ch.epfl.scala.bsp4j.BuildTarget;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class WorkspaceBuildTargetsResult {
+  private List<BuildTarget> targets;
+  
+  public WorkspaceBuildTargetsResult(@NonNull final List<BuildTarget> targets) {
+    this.targets = targets;
+  }
+  
+  @Pure
+  public List<BuildTarget> getTargets() {
+    return this.targets;
+  }
+  
+  public void setTargets(final List<BuildTarget> targets) {
+    this.targets = targets;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("targets", this.targets);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    WorkspaceBuildTargetsResult other = (WorkspaceBuildTargetsResult) obj;
+    if (this.targets == null) {
+      if (other.targets != null)
+        return false;
+    } else if (!this.targets.equals(other.targets))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.targets== null) ? 0 : this.targets.hashCode());
+  }
+}

--- a/bsp4j/src/test/bloop/a/src/main/scala/example/Example.scala
+++ b/bsp4j/src/test/bloop/a/src/main/scala/example/Example.scala
@@ -1,0 +1,9 @@
+package example
+
+import scala.concurrent.Future // unused import
+
+object Example {
+  def main(args: Array[String]): Unit = {
+    println("Hello world!")
+  }
+}

--- a/bsp4j/src/test/bloop/a/src/test/scala/example/ExampleSuite.scala
+++ b/bsp4j/src/test/bloop/a/src/test/scala/example/ExampleSuite.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest.FunSuite
+
+class ExampleSuite extends FunSuite {
+  test("example") {
+    println("Example test!")
+  }
+}

--- a/bsp4j/src/test/bloop/b/src/main/scala/example/SecondExample.scala
+++ b/bsp4j/src/test/bloop/b/src/main/scala/example/SecondExample.scala
@@ -1,0 +1,7 @@
+package example
+
+object SecondExample {
+  def main(args: Array[String]): Unit = {
+    println("Second hello world!")
+  }
+}

--- a/bsp4j/src/test/bloop/b/src/test/scala/example/SecondExampleSuite.scala
+++ b/bsp4j/src/test/bloop/b/src/test/scala/example/SecondExampleSuite.scala
@@ -1,0 +1,9 @@
+package example
+
+import org.scalatest.FunSuite
+
+class SecondExampleSuite extends FunSuite {
+  test("example") {
+    println("Second example test!")
+  }
+}

--- a/bsp4j/src/test/bloop/build.sbt
+++ b/bsp4j/src/test/bloop/build.sbt
@@ -1,0 +1,22 @@
+inThisBuild(List(
+  scalaVersion := "2.12.7",
+  bloopExportJarClassifiers in Global := Some(Set("sources")),
+  libraryDependencies ++= List(
+    "org.scalatest" %% "scalatest" % "3.0.5" % Test
+  )
+))
+
+lazy val a = project
+  .settings(
+    scalacOptions ++= List(
+      "-Yrangepos",
+      "-Ywarn-unused"
+    ),
+    libraryDependencies ++= List(
+      "com.lihaoyi" %% "ujson" % "0.6.6",
+      "org.scalatest" %% "scalatest" % "3.0.5" % Test
+    ),
+    addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.0.0" cross CrossVersion.full)
+  )
+
+lazy val b = project.dependsOn(a)

--- a/bsp4j/src/test/bloop/project/build.properties
+++ b/bsp4j/src/test/bloop/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.4

--- a/bsp4j/src/test/bloop/project/plugins.sbt
+++ b/bsp4j/src/test/bloop/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.0.0")

--- a/bsp4j/src/test/bloop/readme.md
+++ b/bsp4j/src/test/bloop/readme.md
@@ -1,0 +1,3 @@
+# Example bloop project
+
+This project is used for testing the bsp4j integration with bloop.

--- a/bsp4j/src/test/scala/tests/BloopSuite.scala
+++ b/bsp4j/src/test/scala/tests/BloopSuite.scala
@@ -1,0 +1,237 @@
+package tests
+
+import bloop.Cli
+import bloop.cli.CommonOptions
+import bloop.engine.NoPool
+import ch.epfl.scala.bsp4j._
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util
+import java.util.Collections
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import org.scalasbt.ipcsocket.UnixDomainSocket
+import org.scalatest.FunSuite
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import scala.util.Random
+
+trait BloopServer extends BuildServer with ScalaBuildServer
+class BloopClient extends BuildClient {
+  val showMessages = ListBuffer.empty[ShowMessageParams]
+  val logMessages = ListBuffer.empty[LogMessageParams]
+  val diagnostics = ListBuffer.empty[PublishDiagnosticsParams]
+  val compileReports = ListBuffer.empty[CompileReport]
+  def reset(): Unit = {
+    showMessages.clear()
+    logMessages.clear()
+    diagnostics.clear()
+    compileReports.clear()
+  }
+  override def showMessage(params: ShowMessageParams): Unit = showMessages += params
+  override def logMessage(params: LogMessageParams): Unit = logMessages += params
+  override def publishDiagnostics(params: PublishDiagnosticsParams): Unit = diagnostics += params
+  override def didChangeBuildTarget(params: DidChangeBuildTarget): Unit = pprint.log(params)
+  override def registerFileWatcher(
+      params: RegisterFileWatcherParams): CompletableFuture[RegisterFileWatcherResult] = null
+  override def cancelFileWatcher(
+      params: CancelFileWatcherParams): CompletableFuture[CancelFileWatcherResult] = null
+  override def compileReport(params: CompileReport): Unit = compileReports += params
+}
+
+class BloopSuite extends FunSuite {
+  private val props = new java.util.Properties()
+  props.load(this.getClass.getClassLoader.getResourceAsStream("bsp4j.properties"))
+  private val bloopDirectory = Paths.get(props.getProperty("bloopDirectory"))
+
+  def exec(args: String*): Unit = {
+    import sys.process._
+    val exit = Process(args, cwd = bloopDirectory.toFile).!
+    assert(exit == 0)
+  }
+
+  def callBloop(args: String*): Unit = {
+    val ps = System.out
+    val common = CommonOptions(
+      workingDirectory = bloopDirectory.toString,
+      out = ps,
+      err = ps,
+      ngout = ps,
+      ngerr = ps
+    )
+    val action = Cli.parse(args.toArray, common)
+    Cli.run(action, NoPool, args.toArray)
+  }
+
+  def connectToBuildServer(localClient: BuildClient): (BloopServer, Cancelable) = {
+    val tmp = Files.createTempDirectory("bsp")
+    val id = java.lang.Long.toString(Random.nextLong(), Character.MAX_RADIX)
+    val socket = tmp.resolve(s"$id.socket")
+    socket.toFile.deleteOnExit()
+    val args = List[String](
+      "bsp",
+      "--protocol",
+      "local",
+      "--socket",
+      socket.toString
+    )
+    val bspProcess = new Thread {
+      override def run(): Unit = {
+        callBloop(args: _*)
+      }
+    }
+    bspProcess.start()
+    waitForFileToBeCreated(socket, 100, 20)
+    val bloop = new UnixDomainSocket(socket.toFile.getCanonicalPath)
+    val es = Executors.newCachedThreadPool()
+
+    val launcher = new Launcher.Builder[BloopServer]()
+//      .traceMessages(new PrintWriter(System.out))
+      .setRemoteInterface(classOf[BloopServer])
+      .setExecutorService(es)
+      .setInput(bloop.getInputStream)
+      .setOutput(bloop.getOutputStream)
+      .setLocalService(localClient)
+      .create()
+    launcher.startListening()
+    val bsp = launcher.getRemoteProxy
+    localClient.connect(bsp)
+    val cancelable = Cancelable { () =>
+      Cancelable.cancelAll(
+        List(
+          Cancelable(() => bloop.close()),
+          Cancelable(() => bspProcess.interrupt()),
+          Cancelable(() => es.shutdown()),
+        )
+      )
+    }
+    (bsp, cancelable)
+  }
+
+  private def waitForFileToBeCreated(
+      path: Path,
+      retryDelayMillis: Long,
+      maxRetries: Int
+  ): Unit = {
+    if (maxRetries > 0) {
+      if (Files.exists(path)) ()
+      else {
+        Thread.sleep(retryDelayMillis)
+        waitForFileToBeCreated(path, retryDelayMillis, maxRetries - 1)
+      }
+    } else {
+      sys.error(s"no file: $path")
+    }
+  }
+
+  private val gson = new Gson()
+
+  implicit class XtensionBuildTarget(buildTarget: BuildTarget) {
+    def asScalaBuildTarget: ScalaBuildTarget = {
+      gson.fromJson[ScalaBuildTarget](buildTarget.getData.asInstanceOf[JsonElement],
+                                      classOf[ScalaBuildTarget])
+    }
+  }
+
+  def assertWorkspaceBuildTargets(server: BloopServer): Unit = {
+    // workspace/buildTargets
+    val buildTargets = server.workspaceBuildTargets().get().getTargets.asScala
+    assert(buildTargets.length == 6)
+    val scalaBuildTargets = buildTargets.map(_.asScalaBuildTarget)
+    scalaBuildTargets.foreach { scalaBuildTarget =>
+      assert(scalaBuildTarget.getScalaVersion == "2.12.7")
+      val scalaJars = scalaBuildTarget.getJars.asScala
+      List("scala-compiler", "scala-reflect", "scala-library").foreach { scalaJar =>
+        assert(scalaJars.exists(_.contains(scalaJar)), (scalaJars, scalaJar))
+      }
+      // FIXME: scalaBinaryVersion should be 2.12 https://github.com/scalacenter/bloop/issues/677
+      assert(scalaBuildTarget.getScalaBinaryVersion == "2.12.7")
+    }
+  }
+
+  def getBuildTargets(server: BloopServer): util.List[BuildTargetIdentifier] =
+    server.workspaceBuildTargets().get().getTargets.asScala.map(_.getId).asJava
+  def assertScalacOptions(server: BloopServer): Unit = {
+    val scalacOptionsParams = new ScalacOptionsParams(getBuildTargets(server))
+    val scalacOptionsResult = server.buildTargetScalacOptions(scalacOptionsParams).get
+    val scalacOptionsItems = scalacOptionsResult.getItems.asScala
+    scalacOptionsItems.foreach { item =>
+      val options = item.getOptions.asScala
+      val uri = item.getTarget.getUri
+      if (uri.endsWith("a") || uri.endsWith("a-test")) {
+        assert(options.contains("-Yrangepos"))
+        assert(options.exists(_.contains("semanticdb-scalac")))
+      } else if (uri.endsWith("b") || uri.endsWith("b-test")) {
+        assert(options.isEmpty)
+      }
+
+      val classpath = item.getClasspath.asScala
+      assert(classpath.nonEmpty)
+      assert(classpath.exists(_.contains("scala-library")))
+      if (uri.endsWith("a")) {
+        assert(classpath.exists(_.contains("ujson")))
+      }
+    }
+  }
+
+  def assertCompile(server: BloopServer, client: BloopClient): Unit = {
+    client.reset()
+    val params = new CompileParams(getBuildTargets(server))
+    params.setArguments(new JsonArray)
+    val compileResult = server.buildTargetCompile(params).get()
+    // FIXME: originId should be non-null https://github.com/scalacenter/bloop/issues/679
+    assert(compileResult.getOriginId == null)
+    assert(client.logMessages.nonEmpty)
+    assert(client.diagnostics.nonEmpty)
+    assert(client.compileReports.nonEmpty)
+  }
+
+  def assertServerCapabilities(serverCapabilities: BuildServerCapabilities): Unit = {
+    val compiles = serverCapabilities.getCompileProvider.getLanguageIds.asScala
+    val runs = serverCapabilities.getCompileProvider.getLanguageIds.asScala
+    val tests = serverCapabilities.getCompileProvider.getLanguageIds.asScala
+    assert(compiles == Seq("scala", "java"))
+    assert(runs == Seq("scala", "java"))
+    assert(tests == Seq("scala", "java"))
+  }
+
+  def assertServerEndpoints(server: BloopServer, client: BloopClient): Unit = {
+    assertWorkspaceBuildTargets(server)
+    assertScalacOptions(server)
+    assertCompile(server, client)
+    // FIXME: not yet implemented
+    // - buildTarget/test
+    // - buildTarget/run
+    // - buildTarget/mainClasses
+    // - buildTarget/scalaMainClasses
+  }
+
+  test("end to end") {
+    if (!Files.exists(bloopDirectory.resolve("target"))) {
+      exec("sbt", "bloopInstall")
+    }
+    val client = new BloopClient
+    val (server, cancel) = connectToBuildServer(client)
+    try {
+      val capabilities = new BuildClientCapabilities(Collections.singletonList("scala"), false)
+      val initializeParams = new InitializeBuildParams(bloopDirectory.toUri.toString, capabilities)
+      val serverCapabilities = server.initialize(initializeParams).get().getCapabilities
+      server.initialized()
+      try {
+        assertServerCapabilities(serverCapabilities)
+        assertServerEndpoints(server, client)
+      } finally {
+        try server.shutdown()
+        finally server.exit()
+      }
+    } finally {
+      Thread.sleep(1000) // complete server.exit()
+      cancel.cancel()
+    }
+  }
+}

--- a/bsp4j/src/test/scala/tests/Cancelable.scala
+++ b/bsp4j/src/test/scala/tests/Cancelable.scala
@@ -1,0 +1,36 @@
+package tests
+
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+trait Cancelable {
+  def cancel(): Unit
+}
+class OpenCancelable extends Cancelable {
+  private val toCancel = ListBuffer.empty[Cancelable]
+  def add(cancelable: Cancelable): Unit = toCancel += cancelable
+  override def cancel(): Unit = Cancelable.cancelAll(toCancel)
+}
+object Cancelable {
+  def apply(fn: () => Unit): Cancelable = new Cancelable {
+    override def cancel(): Unit = fn()
+  }
+  val empty: Cancelable = Cancelable(() => ())
+  def cancelAll(iterable: Iterable[Cancelable]): Unit = {
+    var errors = ListBuffer.empty[Throwable]
+    iterable.foreach { cancelable =>
+      try cancelable.cancel()
+      catch { case ex if NonFatal(ex) => errors += ex }
+    }
+    errors.toList match {
+      case head :: tail =>
+        tail.foreach { e =>
+          if (e ne head) {
+            head.addSuppressed(e)
+          }
+        }
+        throw head
+      case _ =>
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,9 @@
+inThisBuild(List(
+  scmInfo := Some(ScmInfo(
+    browseUrl = url("https://github.com/scalacenter/bsp"),
+    connection = "scm:git:git@github.com:scalacenter/bsp.git"
+  ))
+))
 import java.io.File
 import org.eclipse.xtend.core.XtendInjectorSingleton
 import org.eclipse.xtend.core.compiler.batch.XtendBatchCompiler

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val bsp4j = project
     javacOptions.in(Compile, doc) := List("-Xdoclint:none"),
     javaHome.in(Compile) := inferJavaHome(),
     javaHome.in(Compile, doc) := inferJavaHome(),
-    TaskKey[Unit]("codegen") := {
+    TaskKey[Unit]("xtend") := {
       val compiler = XtendInjectorSingleton.INJECTOR.getInstance(classOf[XtendBatchCompiler])
       val classpath = dependencyClasspath.in(Compile).value.map(_.data).mkString(File.pathSeparator)
       compiler.setClassPath(classpath)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,15 @@
-val bsp = project
+import java.io.File
+import org.eclipse.xtend.core.XtendInjectorSingleton
+import org.eclipse.xtend.core.compiler.batch.XtendBatchCompiler
+
+// force javac to fork by setting javaHome to get error messages during compilation,
+// see https://github.com/sbt/zinc/issues/520
+def inferJavaHome() =
+  Some(file(System.getProperty("java.home")).getParentFile)
+
+cancelable.in(Global) := true
+
+lazy val bsp = project
   .in(file("."))
   .settings(
     publishArtifact in Test := false,
@@ -8,5 +19,50 @@ val bsp = project
       "io.circe" %% "circe-core" % "0.9.0",
       "io.circe" %% "circe-derivation" % "0.9.0-M4",
       "org.scalameta" %% "lsp4s" % "0.2.0"
+    )
+  )
+
+lazy val bsp4j = project
+  .in(file("bsp4j"))
+  .settings(
+    crossVersion := CrossVersion.disabled,
+    autoScalaLibrary := false,
+    javacOptions.in(Compile) ++= List(
+      "-Xlint:all",
+      "-Werror"
+    ),
+    javacOptions.in(Compile, doc) := List("-Xdoclint:none"),
+    javaHome.in(Compile) := inferJavaHome(),
+    javaHome.in(Compile, doc) := inferJavaHome(),
+    TaskKey[Unit]("codegen") := {
+      val compiler = XtendInjectorSingleton.INJECTOR.getInstance(classOf[XtendBatchCompiler])
+      val classpath = dependencyClasspath.in(Compile).value.map(_.data).mkString(File.pathSeparator)
+      compiler.setClassPath(classpath)
+      val sourceDir = sourceDirectory.in(Compile).value / "java"
+      compiler.setSourcePath(sourceDir.getCanonicalPath)
+      val outDir = sourceDirectory.in(Compile).value / "xtend-gen"
+      IO.delete(outDir)
+      compiler.setOutputPath(outDir.getCanonicalPath)
+      object XtendError
+          extends Exception(s"Compilation of Xtend files in $sourceDir failed.")
+          with sbt.internal.util.FeedbackProvidedException
+      if (!compiler.compile())
+        throw XtendError
+    },
+    unmanagedSourceDirectories.in(Compile) += sourceDirectory.in(Compile).value / "xtend-gen",
+    resourceGenerators.in(Test) += Def.task {
+      val out = managedResourceDirectories.in(Test).value.head / "bsp4j.properties"
+      val props = new java.util.Properties()
+      val bloopDirectory = sourceDirectory.in(Test).value / "bloop"
+      props.put("bloopDirectory", bloopDirectory.getAbsolutePath)
+      IO.write(props, "test data", out)
+      List(out)
+    },
+    libraryDependencies ++= List(
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.generator" % "0.5.0",
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j.jsonrpc" % "0.5.0",
+      "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.0.0" % Test,
+      "ch.epfl.scala" % "bloop-frontend_2.12" % "1.0.0" % Test,
+      "org.scalatest" % "scalatest_2.12" % "3.0.5" % Test
     )
   )

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -712,7 +712,7 @@ Response:
 * result: `BuildTargetTextDocumentsResult`, defined as follows
 
 ```scala
-trait BuildTargetTextDocumentsResponseResult {
+trait BuildTargetTextDocumentsResult {
   /** The source files used by this target */
   def textDocuments: List[TextDocumentIdentifier]
 }
@@ -912,10 +912,10 @@ Response:
 
 ```scala
 trait TestResult {
-  def data: Option[Json] // Note, matches `any | null` in the LSP.
-    
   /** An optional request id to know the origin of this report. */
   def originId: Option[String]
+
+  def data: Option[Json] // Note, matches `any | null` in the LSP.
 }
 ```
 
@@ -1194,7 +1194,7 @@ trait ScalaMainClassesItem {
   def target: BuildTargetIdentifier
 
   /** The main class item. */
-  def mainClass: ScalaMainClass
+  def classes: List[ScalaMainClass]
 }
 
 trait ScalaMainClass {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,8 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.0")
+addSbtCoursier
+
+libraryDependencies ++= Seq(
+  "org.eclipse.xtend" % "org.eclipse.xtend.core" % "2.14.0",
+  "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.0",
+  "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.3.500"
+)

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")


### PR DESCRIPTION
Add a new module `ch.epfl.scala:bsp4j` that is written in pure Java in
the same style as the lsp4j module. The benefit of this module compared
to `ch.epfl.scala:bsp_2.12` is that it has a lower dependency footprint.

Includes a full end-to-end integration test with bloop that stresses the
current implemented endpoints in bloop.  The module implements the full
spec but we can't test all endpoints yet since no server implements
them.

Future work:
- add docstrings for the data structures and endpoints
- add `@NonNull` where necessary