### PR TITLE
Add status code to compile and test

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -388,6 +388,11 @@ class CompileParams {
 class CompileResult {
   String originId
   @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+
+  @NonNull StatusCode statusCode
+  new(@NonNull StatusCode statusCode) {
+    this.statusCode = statusCode
+  }
 }
 
 @JsonRpcData
@@ -418,6 +423,11 @@ class TestParams {
 class TestResult {
   String originId
   @JsonAdapter(JsonElementTypeAdapter.Factory) Object data
+
+  @NonNull StatusCode statusCode
+  new(@NonNull StatusCode statusCode) {
+    this.statusCode = statusCode
+  }
 }
 
 @JsonRpcData

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/CompileResult.java
@@ -1,7 +1,9 @@
 package ch.epfl.scala.bsp4j;
 
+import ch.epfl.scala.bsp4j.StatusCode;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -11,6 +13,13 @@ public class CompileResult {
   
   @JsonAdapter(JsonElementTypeAdapter.Factory.class)
   private Object data;
+  
+  @NonNull
+  private StatusCode statusCode;
+  
+  public CompileResult(@NonNull final StatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
   
   @Pure
   public String getOriginId() {
@@ -30,12 +39,23 @@ public class CompileResult {
     this.data = data;
   }
   
+  @Pure
+  @NonNull
+  public StatusCode getStatusCode() {
+    return this.statusCode;
+  }
+  
+  public void setStatusCode(@NonNull final StatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("originId", this.originId);
     b.add("data", this.data);
+    b.add("statusCode", this.statusCode);
     return b.toString();
   }
   
@@ -59,6 +79,11 @@ public class CompileResult {
         return false;
     } else if (!this.data.equals(other.data))
       return false;
+    if (this.statusCode == null) {
+      if (other.statusCode != null)
+        return false;
+    } else if (!this.statusCode.equals(other.statusCode))
+      return false;
     return true;
   }
   
@@ -68,6 +93,7 @@ public class CompileResult {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
-    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+    result = prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+    return prime * result + ((this.statusCode== null) ? 0 : this.statusCode.hashCode());
   }
 }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TestResult.java
@@ -1,7 +1,9 @@
 package ch.epfl.scala.bsp4j;
 
+import ch.epfl.scala.bsp4j.StatusCode;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -11,6 +13,13 @@ public class TestResult {
   
   @JsonAdapter(JsonElementTypeAdapter.Factory.class)
   private Object data;
+  
+  @NonNull
+  private StatusCode statusCode;
+  
+  public TestResult(@NonNull final StatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
   
   @Pure
   public String getOriginId() {
@@ -30,12 +39,23 @@ public class TestResult {
     this.data = data;
   }
   
+  @Pure
+  @NonNull
+  public StatusCode getStatusCode() {
+    return this.statusCode;
+  }
+  
+  public void setStatusCode(@NonNull final StatusCode statusCode) {
+    this.statusCode = statusCode;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("originId", this.originId);
     b.add("data", this.data);
+    b.add("statusCode", this.statusCode);
     return b.toString();
   }
   
@@ -59,6 +79,11 @@ public class TestResult {
         return false;
     } else if (!this.data.equals(other.data))
       return false;
+    if (this.statusCode == null) {
+      if (other.statusCode != null)
+        return false;
+    } else if (!this.statusCode.equals(other.statusCode))
+      return false;
     return true;
   }
   
@@ -68,6 +93,7 @@ public class TestResult {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
-    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+    result = prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+    return prime * result + ((this.statusCode== null) ? 0 : this.statusCode.hashCode());
   }
 }

--- a/bsp4j/src/test/scala/tests/BloopSuite.scala
+++ b/bsp4j/src/test/scala/tests/BloopSuite.scala
@@ -206,6 +206,8 @@ class BloopSuite extends FunSuite {
     assert(client.logMessages.nonEmpty)
     assert(client.diagnostics.nonEmpty)
     assert(client.compileReports.nonEmpty)
+    // TODO(jvican): Update the status code to OK when bloop implements it
+    assert(compileResult.getStatusCode() == null)
   }
 
   def assertTest(server: BloopServer, client: BloopClient): Unit = {
@@ -217,6 +219,8 @@ class BloopSuite extends FunSuite {
     // Compilation was triggered by `assertCompile`, so no diagnostics are found this time
     assert(client.logMessages.nonEmpty)
     assert(client.testReports.nonEmpty)
+    // TODO(jvican): Update the status code to OK when bloop implements it
+    assert(testResult.getStatusCode() == null)
   }
 
   def assertRun(server: BloopServer, client: BloopClient): Unit = {

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -397,7 +397,8 @@ case object BuildTargetEventKind {
 
 @JsonCodec final case class CompileResult(
     originId: Option[String],
-    data: Option[Json]
+    statusCode: StatusCode,
+    data: Option[Json],
 )
 
 @JsonCodec final case class CompileReport(
@@ -416,7 +417,8 @@ case object BuildTargetEventKind {
 
 @JsonCodec final case class TestResult(
     originId: Option[String],
-    data: Option[Json]
+    statusCode: StatusCode,
+    data: Option[Json],
 )
 
 @JsonCodec final case class TestReport(

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -851,10 +851,26 @@ Response:
 trait CompileResult {
   /** An optional request id to know the origin of this report. */
   def originId: Option[String]
+  
+  /** A status code for the execution. */
+  def statusCode: Int
+
   /** A field containing language-specific information, like products
     * of compilation or compiler-specific metadata the client needs to know. */
   def data: Option[Json] // Note, matches `any | null` in the LSP.
-  
+}
+```
+
+where `StatusCode` is defined as follows
+
+```scala
+object StatusCode {
+  /** Execution was successful. */
+  val Ok = 1
+  /** Execution failed. */
+  val Error = 2
+  /** Execution was cancelled. */
+  val Cancelled = 3
 }
 ```
 
@@ -920,6 +936,9 @@ Response:
 trait TestResult {
   /** An optional request id to know the origin of this report. */
   def originId: Option[String]
+  
+  /** A status code for the execution. */
+  def statusCode: Int
 
   def data: Option[Json] // Note, matches `any | null` in the LSP.
 }
@@ -1007,16 +1026,6 @@ trait RunResult {
   /** A status code for the execution. */
   def statusCode: Int
 }
-
-object StatusCode {
-  /** Execution was successful. */
-  val Ok = 1
-  /** Execution failed. */
-  val Error = 2
-  /** Execution was cancelled. */
-  val Cancelled = 3
-}
-
 ```
 
 This request may trigger a compilation on the selected build targets. The server is free to send any


### PR DESCRIPTION
Replaces the previous mechanism, whereby build tools implementing BSP
would use a BSP protocol error to signal failure in compilation or
testing. Now, this new mechanism will simplify the handling on the
client side.
  
Fixes #41.