### PR TITLE
Rename textDocument/buildTargets into buildTarget/inverseSources (fix #48)

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/BuildServer.java
@@ -26,7 +26,7 @@ public interface BuildServer {
     CompletableFuture<SourcesResult> buildTargetSources(SourcesParams params);
 
     @JsonRequest("textDocument/buildTargets")
-    CompletableFuture<TextDocumentBuildTargetsResult> textDocumentBuildTargets(TextDocumentBuildTargetsParams params);
+    CompletableFuture<InverseSourcesParams> textDocumentBuildTargets(InverseSourcesResult params);
 
     @JsonRequest("buildTarget/dependencySources")
     CompletableFuture<DependencySourcesResult> buildTargetDependencySources(DependencySourcesParams params);

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -101,7 +101,7 @@ class BuildServerCapabilities {
   CompileProvider compileProvider
   TestProvider testProvider
   RunProvider runProvider
-  Boolean textDocumentBuildTargetsProvider
+  Boolean inverseSourcesProvider
   Boolean dependencySourcesProvider
   Boolean resourcesProvider
   Boolean buildTargetChangedProvider
@@ -278,7 +278,7 @@ class SourceItem {
 }
 
 @JsonRpcData
-class TextDocumentBuildTargetsParams {
+class InverseSourcesParams {
   @NonNull List<TextDocumentIdentifier> textDocuments
   new(@NonNull List<TextDocumentIdentifier> textDocuments) {
     this.textDocuments = textDocuments
@@ -286,7 +286,7 @@ class TextDocumentBuildTargetsParams {
 }
 
 @JsonRpcData
-class TextDocumentBuildTargetsResult {
+class InverseSourcesResult {
   @NonNull List<BuildTargetIdentifier> targets
   new(@NonNull List<BuildTargetIdentifier> targets) {
     this.targets = targets

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/BuildServerCapabilities.java
@@ -14,7 +14,7 @@ public class BuildServerCapabilities {
   
   private RunProvider runProvider;
   
-  private Boolean textDocumentBuildTargetsProvider;
+  private Boolean inverseSourcesProvider;
   
   private Boolean dependencySourcesProvider;
   
@@ -50,12 +50,12 @@ public class BuildServerCapabilities {
   }
   
   @Pure
-  public Boolean getTextDocumentBuildTargetsProvider() {
-    return this.textDocumentBuildTargetsProvider;
+  public Boolean getInverseSourcesProvider() {
+    return this.inverseSourcesProvider;
   }
   
-  public void setTextDocumentBuildTargetsProvider(final Boolean textDocumentBuildTargetsProvider) {
-    this.textDocumentBuildTargetsProvider = textDocumentBuildTargetsProvider;
+  public void setInverseSourcesProvider(final Boolean inverseSourcesProvider) {
+    this.inverseSourcesProvider = inverseSourcesProvider;
   }
   
   @Pure
@@ -92,7 +92,7 @@ public class BuildServerCapabilities {
     b.add("compileProvider", this.compileProvider);
     b.add("testProvider", this.testProvider);
     b.add("runProvider", this.runProvider);
-    b.add("textDocumentBuildTargetsProvider", this.textDocumentBuildTargetsProvider);
+    b.add("inverseSourcesProvider", this.inverseSourcesProvider);
     b.add("dependencySourcesProvider", this.dependencySourcesProvider);
     b.add("resourcesProvider", this.resourcesProvider);
     b.add("buildTargetChangedProvider", this.buildTargetChangedProvider);
@@ -124,10 +124,10 @@ public class BuildServerCapabilities {
         return false;
     } else if (!this.runProvider.equals(other.runProvider))
       return false;
-    if (this.textDocumentBuildTargetsProvider == null) {
-      if (other.textDocumentBuildTargetsProvider != null)
+    if (this.inverseSourcesProvider == null) {
+      if (other.inverseSourcesProvider != null)
         return false;
-    } else if (!this.textDocumentBuildTargetsProvider.equals(other.textDocumentBuildTargetsProvider))
+    } else if (!this.inverseSourcesProvider.equals(other.inverseSourcesProvider))
       return false;
     if (this.dependencySourcesProvider == null) {
       if (other.dependencySourcesProvider != null)
@@ -155,7 +155,7 @@ public class BuildServerCapabilities {
     result = prime * result + ((this.compileProvider== null) ? 0 : this.compileProvider.hashCode());
     result = prime * result + ((this.testProvider== null) ? 0 : this.testProvider.hashCode());
     result = prime * result + ((this.runProvider== null) ? 0 : this.runProvider.hashCode());
-    result = prime * result + ((this.textDocumentBuildTargetsProvider== null) ? 0 : this.textDocumentBuildTargetsProvider.hashCode());
+    result = prime * result + ((this.inverseSourcesProvider== null) ? 0 : this.inverseSourcesProvider.hashCode());
     result = prime * result + ((this.dependencySourcesProvider== null) ? 0 : this.dependencySourcesProvider.hashCode());
     result = prime * result + ((this.resourcesProvider== null) ? 0 : this.resourcesProvider.hashCode());
     return prime * result + ((this.buildTargetChangedProvider== null) ? 0 : this.buildTargetChangedProvider.hashCode());

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesParams.java
@@ -7,11 +7,11 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
-public class TextDocumentBuildTargetsParams {
+public class InverseSourcesParams {
   @NonNull
   private List<TextDocumentIdentifier> textDocuments;
   
-  public TextDocumentBuildTargetsParams(@NonNull final List<TextDocumentIdentifier> textDocuments) {
+  public InverseSourcesParams(@NonNull final List<TextDocumentIdentifier> textDocuments) {
     this.textDocuments = textDocuments;
   }
   
@@ -42,7 +42,7 @@ public class TextDocumentBuildTargetsParams {
       return false;
     if (getClass() != obj.getClass())
       return false;
-    TextDocumentBuildTargetsParams other = (TextDocumentBuildTargetsParams) obj;
+    InverseSourcesParams other = (InverseSourcesParams) obj;
     if (this.textDocuments == null) {
       if (other.textDocuments != null)
         return false;

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesResult.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/InverseSourcesResult.java
@@ -7,11 +7,11 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
-public class TextDocumentBuildTargetsResult {
+public class InverseSourcesResult {
   @NonNull
   private List<BuildTargetIdentifier> targets;
   
-  public TextDocumentBuildTargetsResult(@NonNull final List<BuildTargetIdentifier> targets) {
+  public InverseSourcesResult(@NonNull final List<BuildTargetIdentifier> targets) {
     this.targets = targets;
   }
   
@@ -42,7 +42,7 @@ public class TextDocumentBuildTargetsResult {
       return false;
     if (getClass() != obj.getClass())
       return false;
-    TextDocumentBuildTargetsResult other = (TextDocumentBuildTargetsResult) obj;
+    InverseSourcesResult other = (InverseSourcesResult) obj;
     if (this.targets == null) {
       if (other.targets != null)
         return false;

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -294,12 +294,12 @@ case object BuildTargetEventKind {
     generated: Boolean
 )
 
-// Request: 'textDocument/buildTarget', C -> S
-@JsonCodec final case class TextDocumentBuildTargetsParams(
+// Request: 'buildTarget/inverseSources', C -> S
+@JsonCodec final case class InverseSourcesParams(
     textDocument: TextDocumentIdentifier
 )
 
-@JsonCodec final case class TextDocumentBuildTargetsResult(
+@JsonCodec final case class InverseSourcesResult(
     targets: List[BuildTarget]
 )
 

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -28,6 +28,9 @@ trait BuildTarget {
   object sources
     extends Endpoint[DependencySourcesParams, DependencySourcesResult](
       "buildTarget/sources")
+  object inverseSources
+    extends Endpoint[InverseSourcesParams, InverseSourcesResult](
+      "buildTarget/inverseSources")
   object dependencySources
       extends Endpoint[DependencySourcesParams, DependencySourcesResult](
         "buildTarget/dependencySources")

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -319,15 +319,15 @@ trait BuildServerCapabilities {
   
   /** The server provides sources for library dependencies
     * via method buildTarget/dependencySources */
-  def providesDependencySources: Boolean
+  def dependencySourcesProvider: Boolean
   
   /** The server provides all the resource dependencies
     * via method buildTarget/resources */
-  def providesResources: Boolean
+  def resourcesProvider: Boolean
   
   /** The server sends notifications to the client on build
     * target change events via buildTarget/didChange */
-  def providesBuildTargetChanged: Boolean
+  def buildTargetChangedProvider: Boolean
 }
 ```
 

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -314,8 +314,8 @@ trait BuildServerCapabilities {
   }
   
   /** The server can provide a list of targets that contain a
-    * single text document via the method textDocument/buildTargets */
-  def providesTextDocumentBuildTargets: Boolean
+    * single text document via the method buildTarget/inverseSources */
+  def inverseSourcesProvider: Boolean
   
   /** The server provides sources for library dependencies
     * via method buildTarget/dependencySources */
@@ -619,30 +619,27 @@ trait SourceItem {
 }
 ```
 
-### Text Document Build Targets Request
+### Inverse Sources Request
 
-The text document build targets request is sent from the client to the server to query for the list of targets containing the given text document.
+The inverse sources request is sent from the client to the server to query for the list of build targets containing a text document.
 The server communicates during the initialize handshake whether this method is supported or not.
+This request can be viewed as the inverse of `buildTarget/sources`, except it only works for text documents and not directories.
 
-This request may be considered as the inverse of `buildTarget/textDocuments`.
-This method can be used by a language server on `textDocument/didOpen` to lookup which compiler instance to use to compile that given text document.
-In the case there are multiple targets (for example different platforms: JVM/JS, or x86/ARM) containing the same source file, the language server may present in the editor multiple options via `textDocument/codeLens` to configure how to dis-ambiguate.
-
-* method: `textDocument/buildTargets`
-* params: `TextDocumentBuildTargetsParams`, defined as follows
+* method: `textDocument/inverseSources`
+* params: `InverseSourcesParams`, defined as follows
 
 ```scala
-trait TextDocumentBuildTargetsParams {
+trait InverseSourcesParams {
   def textDocument: TextDocumentIdentifier
 }
 ```
 
 Response:
 
-* result: `TextDocumentBuildTargetsResult`, defined as follows
+* result: `InverseSourcesResult`, defined as follows
 
 ```scala
-trait TextDocumentBuildTargetsResult {
+trait InverseSourcesResult {
   def targets: List[BuildTargetIdentifier]
 }
 ```


### PR DESCRIPTION
This new name makes the purpose of this endpoint clearer and also easier to talk and write about.