### PR TITLE
Remove indeterministic call to `build/exit`

### DIFF
--- a/tests/src/test/scala/tests/TypoSuite.scala
+++ b/tests/src/test/scala/tests/TypoSuite.scala
@@ -347,7 +347,6 @@ class TypoSuite extends FunSuite {
           .buildTargetTest(new TestParams(buildTargetUris))
           .toScala
         _ <- scala1.buildShutdown().toScala
-        _ = scala1.onBuildExit()
         // NOTE(olafur): important to not finish test with a notification to avoid Thread.sleep
         // for notification to deliver.
         workspace <- scala1.workspaceBuildTargets().toScala


### PR DESCRIPTION
The CI was flaky due to the fact that we don't control in what order
notificiations deliver. Removing the call to build/exit should be safe
since TypoSuite only tests that bsp4s and bsp4j use the same names.

Fixes #67