### PR TITLE
Add `reset` to `buildTarget/publishDiagnostics`

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -233,11 +233,14 @@ class Diagnostic {
 class PublishDiagnosticsParams {
   @NonNull TextDocumentIdentifier textDocument
   @NonNull BuildTargetIdentifier buildTarget
+  @NonNull List<Diagnostic> diagnostics
+  @NonNull Boolean reset
   String originId
-  List<Diagnostic> diagnostics
-  new(@NonNull TextDocumentIdentifier textDocument, @NonNull BuildTargetIdentifier buildTarget) {
+  new(@NonNull TextDocumentIdentifier textDocument, @NonNull BuildTargetIdentifier buildTarget, @NonNull List<Diagnostic> diagnostics, @NonNull Boolean reset) {
     this.textDocument = textDocument
     this.buildTarget = buildTarget
+    this.diagnostics = diagnostics
+    this.reset = reset
   }
 }
 

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/PublishDiagnosticsParams.java
@@ -16,13 +16,19 @@ public class PublishDiagnosticsParams {
   @NonNull
   private BuildTargetIdentifier buildTarget;
   
-  private String originId;
-  
+  @NonNull
   private List<Diagnostic> diagnostics;
   
-  public PublishDiagnosticsParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final BuildTargetIdentifier buildTarget) {
+  @NonNull
+  private Boolean reset;
+  
+  private String originId;
+  
+  public PublishDiagnosticsParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final BuildTargetIdentifier buildTarget, @NonNull final List<Diagnostic> diagnostics, @NonNull final Boolean reset) {
     this.textDocument = textDocument;
     this.buildTarget = buildTarget;
+    this.diagnostics = diagnostics;
+    this.reset = reset;
   }
   
   @Pure
@@ -46,6 +52,26 @@ public class PublishDiagnosticsParams {
   }
   
   @Pure
+  @NonNull
+  public List<Diagnostic> getDiagnostics() {
+    return this.diagnostics;
+  }
+  
+  public void setDiagnostics(@NonNull final List<Diagnostic> diagnostics) {
+    this.diagnostics = diagnostics;
+  }
+  
+  @Pure
+  @NonNull
+  public Boolean getReset() {
+    return this.reset;
+  }
+  
+  public void setReset(@NonNull final Boolean reset) {
+    this.reset = reset;
+  }
+  
+  @Pure
   public String getOriginId() {
     return this.originId;
   }
@@ -54,23 +80,15 @@ public class PublishDiagnosticsParams {
     this.originId = originId;
   }
   
-  @Pure
-  public List<Diagnostic> getDiagnostics() {
-    return this.diagnostics;
-  }
-  
-  public void setDiagnostics(final List<Diagnostic> diagnostics) {
-    this.diagnostics = diagnostics;
-  }
-  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("textDocument", this.textDocument);
     b.add("buildTarget", this.buildTarget);
-    b.add("originId", this.originId);
     b.add("diagnostics", this.diagnostics);
+    b.add("reset", this.reset);
+    b.add("originId", this.originId);
     return b.toString();
   }
   
@@ -94,15 +112,20 @@ public class PublishDiagnosticsParams {
         return false;
     } else if (!this.buildTarget.equals(other.buildTarget))
       return false;
-    if (this.originId == null) {
-      if (other.originId != null)
-        return false;
-    } else if (!this.originId.equals(other.originId))
-      return false;
     if (this.diagnostics == null) {
       if (other.diagnostics != null)
         return false;
     } else if (!this.diagnostics.equals(other.diagnostics))
+      return false;
+    if (this.reset == null) {
+      if (other.reset != null)
+        return false;
+    } else if (!this.reset.equals(other.reset))
+      return false;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
       return false;
     return true;
   }
@@ -114,7 +137,8 @@ public class PublishDiagnosticsParams {
     int result = 1;
     result = prime * result + ((this.textDocument== null) ? 0 : this.textDocument.hashCode());
     result = prime * result + ((this.buildTarget== null) ? 0 : this.buildTarget.hashCode());
-    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
-    return prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
+    result = prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
+    result = prime * result + ((this.reset== null) ? 0 : this.reset.hashCode());
+    return prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -221,7 +221,8 @@ object DiagnosticSeverity {
     textDocument: TextDocumentIdentifier,
     buildTarget: BuildTargetIdentifier,
     originId: Option[String],
-    diagnostics: List[Diagnostic]
+    diagnostics: List[Diagnostic],
+    reset: Boolean
 )
 
 @JsonCodec final case class WorkspaceBuildTargetsRequest()

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -598,11 +598,12 @@ trait PublishDiagnosticsParams {
 
 where `Diagnostic` is defined as it is in LSP.
 
-When `reset` is enabled, the client must clean all previous diagnostics
+When `reset` is true, the client must clean all previous diagnostics
 associated with the same `textDocument` and `buildTarget` and set instead the
-diagnostics in the request. This is the same behaviour as `BuildTargetParams`
-in the LSP. When `reset` is disabled, the diagnostics are added to the last
-active diagnostics, allowing build tools to stream diagnostics to the client.
+diagnostics in the request. This is the same behaviour as
+`PublishDiagnosticsParams` in the LSP. When `reset` is false, the diagnostics
+are added to the last active diagnostics, allowing build tools to stream
+diagnostics to the client.
 
 It is the server's responsibility to manage the lifetime of the diagnostics by
 using the appropriate value in the `reset` field. Clients generate new

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -568,10 +568,6 @@ defined it in the request that triggered this notification.
 The Diagnostics notification are sent from the server to the client to signal results of validation
 runs.
 
-Unlike the language server protocol, diagnostics are “owned” by the client so it is the client's
-responsibility to manage their lifetime and clear them if necessary. Clients generate new
-diagnostics by calling `buildTarget/compile`.
-
 Notification:
 
 * method: `build/publishDiagnostics`
@@ -593,14 +589,29 @@ trait PublishDiagnosticsParams {
   
   /** The diagnostics to be published by the client. */
   def diagnostics: List[Diagnostic]
+
+  /** Whether the client should clear the previous diagnostics
+    * mapped to the same `textDocument` and `buildTarget`. */
+  def reset: Boolean
 }
 ```
 
 where `Diagnostic` is defined as it is in LSP.
 
-The definition of `PublishDiagnosticsParams` is similar to LSP's but contains the addition of an
-optional `originId` field. Clients can use this id to know which request originated the
-notification. This field will be defined if the client defined it in the original request that
+When `reset` is enabled, the client must clean all previous diagnostics
+associated with the same `textDocument` and `buildTarget` and set instead the
+diagnostics in the request. This is the same behaviour as `BuildTargetParams`
+in the LSP. When `reset` is disabled, the diagnostics are added to the last
+active diagnostics, allowing build tools to stream diagnostics to the client.
+
+It is the server's responsibility to manage the lifetime of the diagnostics by
+using the appropriate value in the `reset` field. Clients generate new
+diagnostics by calling any BSP endpoint that triggers a `buildTarget/compile`,
+such as `buildTarget/compile`, `buildTarget/test` and `buildTarget/run`.
+
+The optional `originId` field in the definition of `PublishDiagnosticsParams`
+can be used by clients to know which request originated the notification. This
+field will be defined if the client defined it in the original request that
 triggered this notification.
 
 ### Workspace Build Targets Request


### PR DESCRIPTION
The previous solution did not allow the client to handle the lifetime of
the diagnostics correctly. For example, when errors disappear in a
buffer, there is no way for the client to know that it should clean
them. Taking another approach in the lifetime handling brings us to
other problems like missing present warnings that are not present during
incremental compilation, see https://github.com/scalacenter/bloop/issues/696

After a discussion with Olafur, we have come up with the following
solution. Reset is a flag that allows servers to tell clients how they
should use the diagnostics. When `reset` is enabled, the behavior is the
same as in the Language Server Protocol. When it isn't enabled, it
allows the build tools to stream errors coming from, say, a compilation
run to the client and letting the client accumulate all of those until
the end of the compilation request.

The following commit makes changes to the code and the protocol spec to
reflect this new workflow.

Co-authored-by: Olafur Pall Geirsson <olafurpg@gmail.com>