### PR TITLE
Improve explanation of `Task Id` section

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -144,7 +144,7 @@ class InitializeBuildResult {
 @JsonRpcData
 class TaskId {
   @NonNull String id
-  String parent
+  List<String> parents
   new(@NonNull String id) {
     this.id = id
   }

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskId.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/TaskId.java
@@ -1,5 +1,6 @@
 package ch.epfl.scala.bsp4j;
 
+import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -9,7 +10,7 @@ public class TaskId {
   @NonNull
   private String id;
   
-  private String parent;
+  private List<String> parents;
   
   public TaskId(@NonNull final String id) {
     this.id = id;
@@ -26,12 +27,12 @@ public class TaskId {
   }
   
   @Pure
-  public String getParent() {
-    return this.parent;
+  public List<String> getParents() {
+    return this.parents;
   }
   
-  public void setParent(final String parent) {
-    this.parent = parent;
+  public void setParents(final List<String> parents) {
+    this.parents = parents;
   }
   
   @Override
@@ -39,7 +40,7 @@ public class TaskId {
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("id", this.id);
-    b.add("parent", this.parent);
+    b.add("parents", this.parents);
     return b.toString();
   }
   
@@ -58,10 +59,10 @@ public class TaskId {
         return false;
     } else if (!this.id.equals(other.id))
       return false;
-    if (this.parent == null) {
-      if (other.parent != null)
+    if (this.parents == null) {
+      if (other.parents != null)
         return false;
-    } else if (!this.parent.equals(other.parent))
+    } else if (!this.parents.equals(other.parents))
       return false;
     return true;
   }
@@ -72,6 +73,6 @@ public class TaskId {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.id== null) ? 0 : this.id.hashCode());
-    return prime * result + ((this.parent== null) ? 0 : this.parent.hashCode());
+    return prime * result + ((this.parents== null) ? 0 : this.parents.hashCode());
   }
 }

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -143,7 +143,7 @@ object MessageType {
 
 @JsonCodec final case class TaskId(
     id: String,
-    parent: Option[String]
+    parents: Option[List[String]]
 )
 
 @JsonCodec final case class ShowMessageParams(

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -251,12 +251,12 @@ trait BuildTargetIdentifer {
 
 ### Task Id 
 
-The Task Id allows clients to uniquely identify a resource and establish a client-parent
-relationship with another id.
+The Task Id allows clients to *uniquely* identify a BSP task and establish a client-parent
+relationship with another task id.
 
 ```scala
 trait TaskId {
-  /** The id */
+  /** The id, it has to be unique. */
   def id: String
 
   /** The parent id. */
@@ -264,11 +264,9 @@ trait TaskId {
 }
 ```
 
-A task id can represent any child-parent relationship established by the build tool.
-
-An example of use of task ids is logs, where BSP clients can use the task ids of logs
-to improve their readability in the user interface. Clients can show logs in a tree fashion, for
-example, or with dropdowns.
+Clients can use Task Ids to improve the user experience. For example, a client can display
+messages reported by `build/taskStart`, `build/taskProgress` and `build/taskFinish` in a
+tree fashion to help readability and convey task dependencies to the user. 
 
 ### Status Code
 

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -256,17 +256,16 @@ relationship with another task id.
 
 ```scala
 trait TaskId {
-  /** The id, it has to be unique. */
+  /** A unique identifier */
   def id: String
 
-  /** The parent id. */
+  /** The parent task id, if any. A non-empty task id means this
+    * task is a sub-task of the parent task. The child-parent
+    * relationship of tasks makes it possible to render tasks in
+    * a tree-like user interface. */
   def parent: Option[String]
 }
 ```
-
-Clients can use Task Ids to improve the user experience. For example, a client can display
-messages reported by `build/taskStart`, `build/taskProgress` and `build/taskFinish` in a
-tree fashion to help readability and convey task dependencies to the user. 
 
 ### Status Code
 

--- a/docs/bsp.md
+++ b/docs/bsp.md
@@ -259,11 +259,12 @@ trait TaskId {
   /** A unique identifier */
   def id: String
 
-  /** The parent task id, if any. A non-empty task id means this
-    * task is a sub-task of the parent task. The child-parent
+  /** The parent task ids, if any. A non-empty parents field means
+    * this task is a sub-task of every parent task id. The child-parent
     * relationship of tasks makes it possible to render tasks in
-    * a tree-like user interface. */
-  def parent: Option[String]
+    * a tree-like user interface or inspect what caused a certain task
+    * execution. */
+  def parents: Option[List[String]]
 }
 ```
 


### PR DESCRIPTION
When implementing the task id bits in bsp v2, I looked at the
specification and found it confusing.

This commit hopefully improves the explanation of `Task Id` and stresses
that the `id` must be unique.