### PR TITLE
add data kinds for scala test params and scala main class 

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/RunParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/RunParamsDataKind.java
@@ -1,0 +1,5 @@
+package ch.epfl.scala.bsp4j;
+
+public class RunParamsDataKind {
+    public static final String SCALA_MAIN_CLASS = "scala-main-class";
+}

--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TestParamsDataKind.java
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/TestParamsDataKind.java
@@ -1,0 +1,5 @@
+package ch.epfl.scala.bsp4j;
+
+public class TestParamsDataKind {
+    public static final String SCALA_TEST = "scala-test";
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -456,6 +456,10 @@ object TestStatus {
     data: Option[Json],
 )
 
+object RunParamsDataKind {
+  val ScalaMainClass = "scala-main-class"
+}
+
 sealed abstract class StatusCode(val code: Int)
 object StatusCode {
   case object Ok extends StatusCode(1)
@@ -562,6 +566,10 @@ object ScalaPlatform {
 @JsonCodec final case class ScalaTestParams(
     testClasses: Option[List[ScalaTestClassesItem]],
 )
+
+object TestParamsDataKind {
+  val ScalaTest = "scala-test"
+}
 
 // Request: 'buildTarget/scalacOptions', C -> S
 @JsonCodec final case class ScalacOptionsParams(


### PR DESCRIPTION
This specifies explicitly the data kind for `ScalaMainClass` and `ScalaTestParams`.

Just a thought: in the future it would be useful to have a single module with those constants to avoid duplication and potential discrepancies