### PR TITLE
add debuggee listening notification

### DIFF
--- a/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
+++ b/bsp4j/src/main/java/ch/epfl/scala/bsp4j/Protocol.xtend
@@ -592,3 +592,13 @@ class TaskFinishParams {
       this.status = status
     }
 }
+
+@JsonRpcData
+class DebuggeeAddress {
+    @NonNull String originId;
+    @NonNull String uri;
+    new(@NonNull String originId, @NonNull String uri){
+        this.originId = originId;
+        this.uri = uri;
+    }
+}

--- a/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebuggeeAddress.java
+++ b/bsp4j/src/main/xtend-gen/ch/epfl/scala/bsp4j/DebuggeeAddress.java
@@ -1,0 +1,80 @@
+package ch.epfl.scala.bsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DebuggeeAddress {
+  @NonNull
+  private String originId;
+  
+  @NonNull
+  private String uri;
+  
+  public DebuggeeAddress(@NonNull final String originId, @NonNull final String uri) {
+    this.originId = originId;
+    this.uri = uri;
+  }
+  
+  @Pure
+  @NonNull
+  public String getOriginId() {
+    return this.originId;
+  }
+  
+  public void setOriginId(@NonNull final String originId) {
+    this.originId = originId;
+  }
+  
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("originId", this.originId);
+    b.add("uri", this.uri);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DebuggeeAddress other = (DebuggeeAddress) obj;
+    if (this.originId == null) {
+      if (other.originId != null)
+        return false;
+    } else if (!this.originId.equals(other.originId))
+      return false;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.originId== null) ? 0 : this.originId.hashCode());
+    return prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+  }
+}

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/Bsp.scala
@@ -625,11 +625,12 @@ object ScalaPlatform {
     children: List[BuildTargetIdentifier],
 )
 
-
 @JsonCodec final case class BspConnectionDetails(
-  name: String,
-  argv: List[String],
-  version: String,
-  bspVersion: String,
-  languages: List[String]
+    name: String,
+    argv: List[String],
+    version: String,
+    bspVersion: String,
+    languages: List[String]
 )
+
+@JsonCodec final case class DebuggeeAddress(originId: Option[String], uri: String)

--- a/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
+++ b/bsp4s/src/main/scala/ch/epfl/scala/bsp/endpoints/Endpoints.scala
@@ -36,6 +36,9 @@ trait BuildTarget {
         "buildTarget/dependencySources")
   object resources extends Endpoint[ResourcesParams, ResourcesResult]("buildTarget/resources")
 
+  object debuggeeListening
+    extends Endpoint[DebuggeeAddress, Unit]("buildTarget/debuggeeListening")
+
   // Scala specific endpoints
   object scalacOptions
       extends Endpoint[ScalacOptionsParams, ScalacOptionsResult]("buildTarget/scalacOptions")


### PR DESCRIPTION
This allows the server to notify the client that the debuggee (run within some `originId`) is accepting connections on the specify address.

This would be useful e.g. in `metals` to add debugging capabilities:
We would run a main class or start some test suites with appropriate jvm options and receive a notification from the server that we can now attach to the debuggee. 